### PR TITLE
Fix extra linkedin url in comment links

### DIFF
--- a/dist/linkedin/linkedin.posts.with.comments.js
+++ b/dist/linkedin/linkedin.posts.with.comments.js
@@ -100,7 +100,12 @@ async function postsWithComments(page, cdp, data) {
       const comments = Array.from(document.querySelectorAll(".comments-post-meta__name-text")).map(nameElement => {
         const name = nameElement.innerText.trim().split("\n")[0];
         const linkElement = nameElement.closest("a");
-        const link = "https://www.linkedin.com" + (linkElement ? linkElement.getAttribute("href") : "");
+        let link = "https://www.linkedin.com";
+
+        if (linkElement) {
+          const url = new URL(linkElement.getAttribute("href"), "https://www.linkedin.com");
+          link = url.href;
+        }
 
         const commentElement = nameElement.closest(".comments-comment-item, .comments-reply-item");
         let comment = "";

--- a/lib/linkedin/linkedin.posts.with.comments.js
+++ b/lib/linkedin/linkedin.posts.with.comments.js
@@ -120,9 +120,12 @@ async function postsWithComments(page, cdp, data) {
       ).map((nameElement) => {
         const name = nameElement.innerText.trim().split("\n")[0];
         const linkElement = nameElement.closest("a");
-        const link =
-          "https://www.linkedin.com" +
-          (linkElement ? linkElement.getAttribute("href") : "");
+        let link = "https://www.linkedin.com";
+
+        if (linkElement) {
+            const url = new URL(linkElement.getAttribute("href"), "https://www.linkedin.com");
+            link = url.href;
+        }
 
         const commentElement = nameElement.closest(
           ".comments-comment-item, .comments-reply-item"


### PR DESCRIPTION
- use javascript URL to build a safe absolute URL for comments from the comment href.

Fixes: #8 