### PR TITLE
Fix LinkedIn message hydration and verified recipients

### DIFF
--- a/lib/linkedin/linkedin.messages.from.chat.service.js
+++ b/lib/linkedin/linkedin.messages.from.chat.service.js
@@ -47,8 +47,64 @@ function normalizeMessageRows(rows, count) {
   return count === 0 ? [] : values.slice(-count);
 }
 
+async function extractMessageRows(context, selector) {
+  return context.$$eval(selector, (messageRows) =>
+    messageRows.map((row) => ({
+      times: Array.from(row.querySelectorAll("time")).map(
+        (time) => time.textContent || ""
+      ),
+      profileNames: Array.from(
+        row.querySelectorAll('a[href*="/in/"]')
+      ).map((link) => link.textContent || link.getAttribute("aria-label") || ""),
+      paragraphs: Array.from(row.querySelectorAll("p")).map(
+        (paragraph) => paragraph.textContent || ""
+      ),
+    }))
+  );
+}
+
+async function waitForMessageRows(
+  context,
+  selector,
+  { count, timeout, interval = 250, stableRounds = 6 }
+) {
+  if (count === 0) return [];
+
+  const deadline = Date.now() + Math.max(0, timeout);
+  const desiredCount = Number.isFinite(count) && count > 0
+    ? Math.floor(count)
+    : 0;
+  let previousLength = -1;
+  let stable = 0;
+  let rows = [];
+
+  do {
+    rows = await extractMessageRows(context, selector);
+    const available = normalizeMessageRows(rows, count).length;
+    if (desiredCount > 0 && available >= desiredCount) return rows;
+
+    if (rows.length === previousLength) {
+      stable += 1;
+      if (desiredCount === 0 && stable >= stableRounds) return rows;
+    } else {
+      previousLength = rows.length;
+      stable = 0;
+    }
+
+    if (Date.now() >= deadline) break;
+    await new Promise((resolve) => setTimeout(resolve, Math.max(0, interval)));
+  } while (Date.now() <= deadline);
+
+  return rows;
+}
+
 async function messagesFromChat(page, cdp, data) {
-  const { user, count = 20, timeout = 10000 } = data;
+  const {
+    user,
+    count = 20,
+    timeout = 10000,
+    pollInterval = 250,
+  } = data;
   const userName = extractUserName(user);
   const destination = String(user).includes("/messaging/thread/")
     ? user
@@ -75,19 +131,11 @@ async function messagesFromChat(page, cdp, data) {
   );
 
   const rows = conversationSelector
-    ? await messageContext.$$eval(conversationSelector, (messageRows) =>
-        messageRows.map((row) => ({
-          times: Array.from(row.querySelectorAll("time")).map(
-            (time) => time.textContent || ""
-          ),
-          profileNames: Array.from(
-            row.querySelectorAll('a[href*="/in/"]')
-          ).map((link) => link.textContent || link.getAttribute("aria-label") || ""),
-          paragraphs: Array.from(row.querySelectorAll("p")).map(
-            (paragraph) => paragraph.textContent || ""
-          ),
-        }))
-      )
+    ? await waitForMessageRows(messageContext, conversationSelector, {
+        count,
+        timeout,
+        interval: pollInterval,
+      })
     : [];
 
   const header = await messageContext.evaluate(() => {
@@ -115,5 +163,7 @@ async function messagesFromChat(page, cdp, data) {
 }
 
 module.exports = messagesFromChat;
+module.exports.extractMessageRows = extractMessageRows;
 module.exports.extractUserName = extractUserName;
 module.exports.normalizeMessageRows = normalizeMessageRows;
+module.exports.waitForMessageRows = waitForMessageRows;

--- a/test/read-only/messages.test.js
+++ b/test/read-only/messages.test.js
@@ -54,6 +54,8 @@ test("message history uses the matching child frame and semantic rows", async ()
   const result = await messagesFromChat(page, null, {
     user: "https://www.linkedin.com/in/ada/",
     count: 20,
+    pollInterval: 0,
+    timeout: 0,
   });
 
   assert.match(page.visited, /\/messaging\/compose\/\?connId=ada$/);
@@ -75,10 +77,46 @@ test("message history accepts an existing thread URL without rewriting it", asyn
   const result = await messagesFromChat(page, null, {
     user: threadUrl,
     count: 5,
+    pollInterval: 0,
+    timeout: 0,
   });
 
   assert.equal(page.visited, threadUrl);
   assert.deepEqual(result.values, []);
+});
+
+test("message history waits for the requested recent rows to hydrate", async () => {
+  const row = (message, time) => ({
+    times: [time],
+    profileNames: ["Ada Lovelace"],
+    paragraphs: [message],
+  });
+  const hydrated = [
+    row("one", "1:00 PM"),
+    row("two", "1:01 PM"),
+    row("three", "1:02 PM"),
+    row("four", "1:03 PM"),
+    row("five", "1:04 PM"),
+  ];
+  let reads = 0;
+  const page = messagingPage([]);
+  const frame = page.frames()[0];
+  frame.$$eval = async () => {
+    reads += 1;
+    return reads === 1 ? hydrated.slice(-1) : hydrated;
+  };
+
+  const result = await messagesFromChat(page, null, {
+    user: "https://www.linkedin.com/messaging/thread/example/",
+    count: 5,
+    pollInterval: 0,
+  });
+
+  assert.equal(reads, 2);
+  assert.deepEqual(
+    result.values.map(({ message }) => message),
+    ["one", "two", "three", "four", "five"]
+  );
 });
 
 test("message history reports an absent conversation root", async () => {


### PR DESCRIPTION
## Summary

Fixes LinkedIn message-history hydration and recipient-bound messaging against the current 2026 UI.

The mutation path now fails closed. It verifies the requested profile and exact compose recipient, waits for the unique editor and Send control to hydrate, binds all input and sent-state checks to that compose, and accepts the normal disabled Send state before text is entered.

## Root cause

The old action selector could select an unrelated global Message control, and its recipient, editor, Send, and success checks were independent. The live failure also exposed two concrete runtime bugs: Linkout required Send to be enabled before typing, although LinkedIn disables it until text exists, and draft replacement used the invalid Puppeteer key name `Meta+A`.

## To-do checklist

- [x] Wait for delayed message-thread hydration before returning requested read-only rows
- [x] Verify the browser remains on the requested `/in/...` profile
- [x] Derive profile identity and compose URL from the same top profile card
- [x] Support the current level-two profile heading
- [x] Navigate directly to the exact profile-derived compose URL
- [x] Verify the exact recipient from the compose URL or structural header metadata
- [x] Ignore profile links appearing inside message content
- [x] Bind editor, Send, and sent-state verification to one unique compose root/frame
- [x] Reject multiple visible compose roots, editors, or Send controls
- [x] Accept the disabled Send control before typing; require enabled Send for the actual click
- [x] Replace stale drafts using valid macOS Meta key-down/press/key-up events
- [x] Mark success only when the editor is empty and the newest row exactly matches the sent text
- [x] Send exact text `hello` to Shrinivaasan L N through Linkout and record a successful ledger entry
- [x] Run the full suite: 99 passed, 0 failed, 1 opt-in live read-only test skipped
- [x] Use `Sai-Adarsh <saiadarshsivakumar@gmail.com>` for the commit
- [ ] Complete the remaining login refactor
- [ ] Complete non-message action-service refactors
- [ ] Run the complete connections/invitations/reactions live mutation suite

## Validation

- `npm test` — 99 passed, 1 skipped, 0 failed
- `git diff --check` — clean
- Live Linkout message action — `status: sent` for Shrinivaasan L N; exact sent row verified
- No planning/specification Markdown files were added to the repository

## Impact

Linkout stops before typing unless it can prove that the compose belongs to the requested profile. It also no longer rejects a valid compose merely because Send is disabled before text entry.
