### PR TITLE
Harden all read-only live checks

### DIFF
--- a/lib/helpers/find-page-context.js
+++ b/lib/helpers/find-page-context.js
@@ -1,5 +1,15 @@
 const LinkoutError = require("../errors/linkout-error");
 
+function isDetachedContextError(error) {
+  const message = String((error && error.message) || "");
+  return [
+    /attempted to use detached frame/i,
+    /cannot find context with specified id/i,
+    /execution context was destroyed/i,
+    /execution context is not available in detached frame or worker/i,
+  ].some((pattern) => pattern.test(message));
+}
+
 async function findFirstSelector(context, selectors) {
   for (const selector of selectors) {
     if (await context.$(selector)) {
@@ -81,12 +91,22 @@ async function resolveSelector(
 }
 
 async function findPageContext(page, selectors) {
+  if (await findFirstSelector(page, selectors)) {
+    return page;
+  }
+
   const frames = typeof page.frames === "function" ? page.frames() : [];
-  const contexts = [...new Set([page, ...frames])];
+  const contexts = [...new Set(frames)].filter((context) => context !== page);
 
   for (const context of contexts) {
-    if (await findFirstSelector(context, selectors)) {
-      return context;
+    try {
+      if (await findFirstSelector(context, selectors)) {
+        return context;
+      }
+    } catch (error) {
+      if (!isDetachedContextError(error)) {
+        throw error;
+      }
     }
   }
 

--- a/lib/helpers/scrape-activity.js
+++ b/lib/helpers/scrape-activity.js
@@ -55,7 +55,10 @@ async function scrapeActivityPage(
   page,
   { url, count = 20, timeout = 10000 }
 ) {
-  await page.goto(url);
+  await page.goto(url, {
+    waitUntil: "domcontentloaded",
+    timeout: 60000,
+  });
 
   const context = await waitForPageContext(page, selectors.activity.cards, {
     timeout,

--- a/test/live/read-only-source.test.js
+++ b/test/live/read-only-source.test.js
@@ -28,3 +28,20 @@ test("live selector smoke harness cannot perform browser input or mutations", ()
   }
 });
 
+test("live selector smoke harness exercises every read-only service", () => {
+  const source = fs.readFileSync(smokePath, "utf8");
+  const services = [
+    "visit",
+    "connectionStatus",
+    "acceptedConnections",
+    "messagesFromChat",
+    "posts",
+    "reactions",
+    "comments",
+    "postsWithComments",
+  ];
+
+  for (const service of services) {
+    assert.match(source, new RegExp(`Linkout\\.services\\.${service}\\s*\\(`));
+  }
+});

--- a/test/live/read-only.smoke.js
+++ b/test/live/read-only.smoke.js
@@ -26,6 +26,19 @@ async function requireHealthyPage(page, stage) {
   assert.equal(state.state, "authenticated");
 }
 
+function activityURLFromResults(posts, reactions, comments) {
+  const candidates = [
+    ...(Array.isArray(posts) ? posts : []),
+    ...((reactions && Array.isArray(reactions.values)) ? reactions.values : []),
+    ...((comments && Array.isArray(comments.values)) ? comments.values : []),
+  ];
+  return candidates
+    .map((candidate) => String(candidate.link || candidate.url || ""))
+    .find((url) =>
+      /^https:\/\/www\.linkedin\.com\/(?:feed\/update|posts)\//.test(url)
+    );
+}
+
 test(
   "live read-only selectors match in visible local Chrome",
   { skip: !enabled },
@@ -86,10 +99,37 @@ test(
         count: 1,
       });
       assert.ok(Array.isArray(posts));
-      await requireHealthyPage(page, "after activity extraction");
+      await requireHealthyPage(page, "after post extraction");
+
+      const reactions = await Linkout.services.reactions(page, null, {
+        user: approvedProfileURL,
+        count: 1,
+      });
+      assert.ok(reactions && Array.isArray(reactions.values));
+      await requireHealthyPage(page, "after reaction extraction");
+
+      const comments = await Linkout.services.comments(page, null, {
+        user: approvedProfileURL,
+        count: 1,
+      });
+      assert.ok(comments && Array.isArray(comments.values));
+      await requireHealthyPage(page, "after comment extraction");
+
+      const activityURL = activityURLFromResults(posts, reactions, comments);
+      assert.ok(activityURL, "The approved profile has no readable activity URL");
+      const approvedActivityURL = requireLinkedInURL(
+        activityURL,
+        /^\/(?:feed\/update|posts)\//
+      );
+      const postWithComments = await Linkout.services.postsWithComments(
+        page,
+        null,
+        { url: approvedActivityURL }
+      );
+      assert.ok(postWithComments && Array.isArray(postWithComments.comments));
+      await requireHealthyPage(page, "after post-with-comments extraction");
     } finally {
       await browser.disconnect();
     }
   }
 );
-

--- a/test/read-only/activity.test.js
+++ b/test/read-only/activity.test.js
@@ -50,10 +50,12 @@ function activityPage(rows = fixtureRows) {
 
   return {
     visited: null,
+    navigationOptions: null,
     clicked: false,
     frames: () => [],
-    async goto(url) {
+    async goto(url, options) {
       this.visited = url;
+      this.navigationOptions = options;
     },
     async $(selector) {
       return selector === cardSelector ? {} : null;
@@ -97,6 +99,21 @@ test("activity page extraction does not click controls", async () => {
       url: "https://www.linkedin.com/feed/update/urn:li:activity:456/",
     },
   ]);
+});
+
+test("activity navigation enforces a 60-second DOM-ready ceiling", async () => {
+  const page = activityPage();
+  await scrapeActivityPage(page, {
+    url: "https://www.linkedin.com/in/example/recent-activity/all/",
+    count: 1,
+    timeout: 0,
+    navigationTimeout: Infinity,
+  });
+
+  assert.deepEqual(page.navigationOptions, {
+    waitUntil: "domcontentloaded",
+    timeout: 60000,
+  });
 });
 
 test("activity normalization returns no rows for a zero count", () => {

--- a/test/read-only/find-page-context.test.js
+++ b/test/read-only/find-page-context.test.js
@@ -45,6 +45,52 @@ test("findPageContext returns null when no candidate matches", async () => {
   assert.equal(await findPageContext(page, ["main"]), null);
 });
 
+test("findPageContext skips child frames detached during selector lookup", async () => {
+  const detachedMessages = [
+    "Attempted to use detached Frame 'frame-id'",
+    "Protocol error (DOM.describeNode): Cannot find context with specified id",
+    "Execution context was destroyed, most likely because of a navigation",
+    "Execution context is not available in detached frame or worker 'frame-id'",
+  ];
+  const detachedFrames = detachedMessages.map((message) => ({
+    async $() {
+      throw new Error(message);
+    },
+  }));
+  const stableFrame = context({ main: { id: "stable" } });
+  const page = Object.assign(context(), {
+    frames: () => [page, ...detachedFrames, stableFrame],
+  });
+
+  assert.equal(await findPageContext(page, ["main"]), stableFrame);
+});
+
+test("findPageContext preserves transient failures from the main page", async () => {
+  const failure = new Error(
+    "Execution context was destroyed, most likely because of a navigation"
+  );
+  const page = {
+    frames: () => [page, context({ main: { id: "frame" } })],
+    async $() {
+      throw failure;
+    },
+  };
+
+  await assert.rejects(() => findPageContext(page, ["main"]), failure);
+});
+
+test("findPageContext preserves unexpected child-frame failures", async () => {
+  const failure = new Error("CDP session closed unexpectedly");
+  const frame = {
+    async $() {
+      throw failure;
+    },
+  };
+  const page = Object.assign(context(), { frames: () => [page, frame] });
+
+  await assert.rejects(() => findPageContext(page, ["main"]), failure);
+});
+
 test("waitForPageContext retries until dynamic content appears", async () => {
   let attempts = 0;
   const page = {


### PR DESCRIPTION
## Summary

- Bound LinkedIn activity navigation to `DOMContentLoaded` with a fixed 60-second ceiling.
- Ignore only recognized detached child-frame races while preserving main-page and unexpected failures.
- Exercise all eight read-only services in the permanent authenticated Chrome smoke suite.

## Checklist

- [x] Add regression coverage for bounded activity navigation
- [x] Cover Puppeteer 25 detached-frame error variants
- [x] Preserve main-page and unexpected selector failures
- [x] Test profile, connection status, connections, messages, posts, reactions, comments, and post-with-comments
- [x] Keep the live harness free of clicks, typing, messages, invitations, likes, endorsements, and login automation
- [x] Run offline suite: 105 passed, 1 opt-in live test skipped, 0 failed
- [x] Run authenticated all-eight live suite: 1 passed, 0 failed
- [x] Complete independent code review with no Critical or Important findings
- [ ] Test action and mutation services (out of scope for this read-only PR)

No design or specification Markdown files are included.
