### PR TITLE
Harden visible LinkedIn action selectors

### DIFF
--- a/lib/helpers/find-page-context.js
+++ b/lib/helpers/find-page-context.js
@@ -30,15 +30,67 @@ async function sanitizePageUrl(page) {
   }
 }
 
-async function isVisible(handle) {
+async function hasVisibleStyle(handle) {
   if (!handle) return false;
-  if (typeof handle.isIntersectingViewport !== "function") return true;
+  if (typeof handle.isVisible !== "function") return true;
+  return handle.isVisible();
+}
 
-  try {
-    return await handle.isIntersectingViewport();
-  } catch (_) {
-    return false;
+async function isVisible(handle) {
+  if (!(await hasVisibleStyle(handle))) return false;
+  if (typeof handle.isIntersectingViewport !== "function") return true;
+  return handle.isIntersectingViewport();
+}
+
+async function isRendered(handle) {
+  if (!handle || typeof handle.boundingBox !== "function") return false;
+  if (!(await hasVisibleStyle(handle))) return false;
+  return Boolean(await handle.boundingBox());
+}
+
+async function disposeHandles(handles, selected, primaryError) {
+  let cleanupError;
+  for (const handle of handles) {
+    if (handle === selected || typeof handle.dispose !== "function") continue;
+    try {
+      await handle.dispose();
+    } catch (error) {
+      cleanupError ||= error;
+    }
   }
+  if (primaryError) throw primaryError;
+  if (cleanupError) throw cleanupError;
+}
+
+async function findMatchingHandle(
+  context,
+  selector,
+  visible,
+  allowOffscreen
+) {
+  const handles = typeof context.$$ === "function"
+    ? await context.$$(selector)
+    : [await context.$(selector)].filter(Boolean);
+
+  let selected = null;
+  let primaryError;
+  try {
+    for (const handle of handles) {
+      if (
+        !visible ||
+        (await isVisible(handle)) ||
+        (allowOffscreen && (await isRendered(handle)))
+      ) {
+        selected = handle;
+        break;
+      }
+    }
+  } catch (error) {
+    primaryError = error;
+  }
+
+  await disposeHandles(handles, selected, primaryError);
+  return selected;
 }
 
 async function resolveSelector(
@@ -50,6 +102,7 @@ async function resolveSelector(
     timeout = 10000,
     interval = 250,
     visible = false,
+    allowOffscreen = false,
   }
 ) {
   if (!Array.isArray(candidates) || candidates.length === 0) {
@@ -63,10 +116,21 @@ async function resolveSelector(
     const contexts = [...new Set([page, ...frames])];
 
     for (const context of contexts) {
-      for (const selector of candidates) {
-        const handle = await context.$(selector);
-        if (handle && (!visible || (await isVisible(handle)))) {
-          return { context, selector, handle };
+      try {
+        for (const selector of candidates) {
+          const handle = await findMatchingHandle(
+            context,
+            selector,
+            visible,
+            allowOffscreen
+          );
+          if (handle) {
+            return { context, selector, handle };
+          }
+        }
+      } catch (error) {
+        if (context === page || !isDetachedContextError(error)) {
+          throw error;
         }
       }
     }

--- a/lib/interactions/browser-input.js
+++ b/lib/interactions/browser-input.js
@@ -30,6 +30,9 @@ async function clickVisible(
   if (!preferNative && page.cursor && typeof page.cursor.click === "function") {
     await page.cursor.click(target);
   } else {
+    if (target && typeof target.scrollIntoView === "function") {
+      await target.scrollIntoView();
+    }
     const box = target && typeof target.boundingBox === "function"
       ? await target.boundingBox()
       : null;

--- a/lib/linkedin/linkedin.connect.service.js
+++ b/lib/linkedin/linkedin.connect.service.js
@@ -3,9 +3,9 @@ const generateMessage = require("../helpers/generateMessage");
 const LinkoutError = require("../errors/linkout-error");
 const selectors = require("../selectors/actions").connect;
 const {
+  assertAction,
   clickAction,
   getActionPolicy,
-  resolveAction,
   typeAction,
 } = require("./mutation-runtime");
 
@@ -50,7 +50,7 @@ async function connect(page, cdp, data = {}) {
       );
     }
     await clickAction(page, "connect", "send", selectors.send, data);
-    await resolveAction(page, "connect", "success", selectors.success, data);
+    await assertAction(page, "connect", "success", selectors.success, data);
     await transaction.complete();
     return { status: "sent", profileData };
   } catch (error) {

--- a/lib/linkedin/linkedin.endorse.service.js
+++ b/lib/linkedin/linkedin.endorse.service.js
@@ -1,10 +1,60 @@
 const createLinkedinUrl = require("../helpers/create.linkedin.url");
+const LinkoutError = require("../errors/linkout-error");
+const { clickVisible } = require("../interactions/browser-input");
+const { sleep } = require("../interactions/timing");
 const selectors = require("../selectors/actions").endorse;
 const {
-  clickAction,
+  disposeResolved,
   getActionPolicy,
+  interactionOptions,
   resolveAction,
 } = require("./mutation-runtime");
+
+async function readEndorsementState(handle) {
+  return handle.evaluate((element) => ({
+    label: String(element.getAttribute("aria-label") || "").trim(),
+    pressed: element.getAttribute("aria-pressed") === "true",
+  }));
+}
+
+function endorsementSkill(label) {
+  const match = String(label || "").trim().match(/^Endorse\s+(.+)$/i);
+  return match ? match[1].trim() : "";
+}
+
+function isEndorsedState(state, skill) {
+  const label = String((state && state.label) || "").trim().toLowerCase();
+  const expected = String(skill || "").trim().toLowerCase();
+  return Boolean(
+    state &&
+    (
+      state.pressed === true ||
+      label === `endorsed ${expected}` ||
+      label.startsWith("remove endorsement")
+    )
+  );
+}
+
+async function waitForEndorsement(
+  handle,
+  skill,
+  { timeout = 10000, interval = 250 } = {}
+) {
+  const deadline = Date.now() + Math.max(0, timeout);
+  do {
+    if (isEndorsedState(await readEndorsementState(handle), skill)) return;
+    if (Date.now() >= deadline) break;
+    await sleep(Math.min(
+      Math.max(0, interval),
+      Math.max(0, deadline - Date.now())
+    ));
+  } while (Date.now() <= deadline);
+
+  throw new LinkoutError(
+    "ENDORSEMENT_NOT_VERIFIED",
+    `LinkedIn did not confirm endorsement for ${skill}`
+  );
+}
 
 async function endorse(page, cdp, data = {}) {
   const target = await createLinkedinUrl(data.url, 3);
@@ -17,8 +67,36 @@ async function endorse(page, cdp, data = {}) {
   });
 
   try {
-    await clickAction(page, "endorse", "button", selectors.button, data);
-    await resolveAction(page, "endorse", "success", selectors.success, data);
+    const resolved = await resolveAction(
+      page,
+      "endorse",
+      "button",
+      selectors.button,
+      data
+    );
+    let primaryError;
+    try {
+      const skill = endorsementSkill((await readEndorsementState(resolved.handle)).label);
+      if (!skill) {
+        throw new LinkoutError(
+          "ENDORSEMENT_TARGET_NOT_IDENTIFIED",
+          "Could not identify the skill attached to the Endorse control"
+        );
+      }
+      await clickVisible(page, resolved.handle, {
+        ...interactionOptions(data),
+        preferNative: resolved.context !== page,
+      });
+      await waitForEndorsement(resolved.handle, skill, {
+        timeout: data.timeout === undefined ? 10000 : data.timeout,
+        interval: data.interval === undefined ? 250 : data.interval,
+      });
+    } catch (error) {
+      primaryError = error;
+      throw error;
+    } finally {
+      await disposeResolved(resolved, primaryError);
+    }
     await transaction.complete();
     return { status: "completed", url: target };
   } catch (error) {
@@ -28,3 +106,6 @@ async function endorse(page, cdp, data = {}) {
 }
 
 module.exports = endorse;
+module.exports.endorsementSkill = endorsementSkill;
+module.exports.isEndorsedState = isEndorsedState;
+module.exports.waitForEndorsement = waitForEndorsement;

--- a/lib/linkedin/linkedin.like.service.js
+++ b/lib/linkedin/linkedin.like.service.js
@@ -1,9 +1,9 @@
 const createLinkedinUrl = require("../helpers/create.linkedin.url");
 const selectors = require("../selectors/actions").like;
 const {
+  assertAction,
   clickAction,
   getActionPolicy,
-  resolveAction,
 } = require("./mutation-runtime");
 
 async function like(page, cdp, data = {}) {
@@ -18,7 +18,7 @@ async function like(page, cdp, data = {}) {
 
   try {
     await clickAction(page, "like", "button", selectors.button, data);
-    await resolveAction(page, "like", "success", selectors.success, data);
+    await assertAction(page, "like", "success", selectors.success, data);
     await transaction.complete();
     return { status: "completed", url: target };
   } catch (error) {

--- a/lib/linkedin/linkedin.message.service.js
+++ b/lib/linkedin/linkedin.message.service.js
@@ -5,6 +5,7 @@ const { detectPageState } = require("../browser/detect-page-state");
 const { clickVisible, typeVisible } = require("../interactions/browser-input");
 const { sleep } = require("../interactions/timing");
 const {
+  disposeResolved,
   getActionPolicy,
   interactionOptions,
   resolveAction,
@@ -63,7 +64,16 @@ async function resolveProfileMessageTarget(page, requestedUrl, data = {}) {
     throw error;
   }
 
-  const target = await inspectProfileMessageTarget(resolved.handle);
+  let target;
+  let primaryError;
+  try {
+    target = await inspectProfileMessageTarget(resolved.handle);
+  } catch (error) {
+    primaryError = error;
+    throw error;
+  } finally {
+    await disposeResolved(resolved, primaryError);
+  }
   let composeUrl;
   try {
     composeUrl = new URL(target.href, "https://www.linkedin.com");
@@ -80,7 +90,8 @@ async function resolveProfileMessageTarget(page, requestedUrl, data = {}) {
 
   const [firstName = "", ...remainingNameParts] = target.fullName.split(" ");
   return {
-    ...resolved,
+    context: resolved.context,
+    selector: resolved.selector,
     href: composeUrl.href,
     profilePath: requestedPath,
     recipient,

--- a/lib/linkedin/linkedin.sales.nav.scraper.js
+++ b/lib/linkedin/linkedin.sales.nav.scraper.js
@@ -1,7 +1,9 @@
 const LinkoutError = require("../errors/linkout-error");
 const selectors = require("../selectors/sales-navigator");
 const {
+  assertAction,
   clickAction,
+  disposeResolved,
   getActionPolicy,
   resolveAction,
   typeAction,
@@ -90,7 +92,7 @@ async function applyFilter(page, name, values, data) {
   const definition = FILTER_DEFINITIONS[name];
   if (!definition) throw new LinkoutError("INVALID_FILTER", `Unsupported filter: ${name}`);
 
-  await resolveAction(page, "salesNavigator", `${name}.root`, definition.root, data);
+  await assertAction(page, "salesNavigator", `${name}.root`, definition.root, data);
   try {
     await clickAction(page, "salesNavigator", `${name}.toggle`, definition.toggle, data);
   } catch (error) {
@@ -144,33 +146,41 @@ async function extractRows(page, leadType, data) {
     selectors.results.item,
     data
   );
-  return resolved.context.$$eval(resolved.selector, (items, type) => {
-    const text = (element) =>
-      String((element && element.textContent) || "").trim().replace(/\s+/g, " ");
-    const href = (element) =>
-      String((element && (element.href || element.getAttribute("href"))) || "");
+  let primaryError;
+  try {
+    return await resolved.context.$$eval(resolved.selector, (items, type) => {
+      const text = (element) =>
+        String((element && element.textContent) || "").trim().replace(/\s+/g, " ");
+      const href = (element) =>
+        String((element && (element.href || element.getAttribute("href"))) || "");
 
-    return items.map((item) => {
-      if (type === "people") {
-        const name = item.querySelector('[data-anonymize="person-name"]');
+      return items.map((item) => {
+        if (type === "people") {
+          const name = item.querySelector('[data-anonymize="person-name"]');
+          return {
+            name: text(name),
+            title: text(item.querySelector('[data-anonymize="title"]')),
+            url: href(name && name.closest("a")),
+            company: text(item.querySelector('[data-anonymize="company-name"]')),
+            location: text(item.querySelector('[data-anonymize="location"]')),
+            jobTitle: text(item.querySelector('[data-anonymize="job-title"]')),
+          };
+        }
+        const company = item.querySelector('[data-anonymize="company-name"]');
         return {
-          name: text(name),
-          title: text(item.querySelector('[data-anonymize="title"]')),
-          url: href(name && name.closest("a")),
-          company: text(item.querySelector('[data-anonymize="company-name"]')),
-          location: text(item.querySelector('[data-anonymize="location"]')),
-          jobTitle: text(item.querySelector('[data-anonymize="job-title"]')),
+          company_name: text(company),
+          url: href(company && company.closest("a")),
+          industry: text(item.querySelector('[data-anonymize="industry"]')),
+          size: text(item.querySelector('[data-anonymize="company-size"]')),
         };
-      }
-      const company = item.querySelector('[data-anonymize="company-name"]');
-      return {
-        company_name: text(company),
-        url: href(company && company.closest("a")),
-        industry: text(item.querySelector('[data-anonymize="industry"]')),
-        size: text(item.querySelector('[data-anonymize="company-size"]')),
-      };
-    });
-  }, leadType);
+      });
+    }, leadType);
+  } catch (error) {
+    primaryError = error;
+    throw error;
+  } finally {
+    await disposeResolved(resolved, primaryError);
+  }
 }
 
 function pageUrl(base, pageNumber) {
@@ -198,7 +208,7 @@ async function salesNavScraper(page, cdp, data = {}) {
     });
     try {
       await applyFilters(page, filterParams, data);
-      await resolveAction(
+      await assertAction(
         page,
         "salesNavigator",
         "results.list",

--- a/lib/linkedin/mutation-runtime.js
+++ b/lib/linkedin/mutation-runtime.js
@@ -17,6 +17,20 @@ function interactionOptions(data = {}) {
   };
 }
 
+async function disposeResolved(resolved, primaryError) {
+  const handle = resolved && resolved.handle;
+  let cleanupError;
+  if (handle && typeof handle.dispose === "function") {
+    try {
+      await handle.dispose();
+    } catch (error) {
+      cleanupError = error;
+    }
+  }
+  if (primaryError) throw primaryError;
+  if (cleanupError) throw cleanupError;
+}
+
 async function resolveAction(page, workflow, name, candidates, data = {}) {
   return resolveSelector(page, {
     workflow,
@@ -25,33 +39,59 @@ async function resolveAction(page, workflow, name, candidates, data = {}) {
     timeout: data.timeout === undefined ? 10000 : data.timeout,
     interval: data.interval === undefined ? 250 : data.interval,
     visible: true,
+    allowOffscreen: true,
   });
+}
+
+async function assertAction(page, workflow, name, candidates, data = {}) {
+  const resolved = await resolveAction(page, workflow, name, candidates, data);
+  await disposeResolved(resolved);
+  return resolved;
 }
 
 async function clickAction(page, workflow, name, candidates, data = {}) {
   const resolved = await resolveAction(page, workflow, name, candidates, data);
-  await clickVisible(page, resolved.handle, {
-    ...interactionOptions(data),
-    preferNative: resolved.context !== page,
-  });
+  let primaryError;
+  try {
+    await clickVisible(page, resolved.handle, {
+      ...interactionOptions(data),
+      preferNative: resolved.context !== page,
+    });
+  } catch (error) {
+    primaryError = error;
+    throw error;
+  } finally {
+    await disposeResolved(resolved, primaryError);
+  }
   return resolved;
 }
 
 async function typeAction(page, workflow, name, candidates, text, data = {}) {
   const resolved = await resolveAction(page, workflow, name, candidates, data);
-  await typeVisible(page, resolved.selector, text, {
-    context: resolved.context,
-    detectState: data.detectState,
-    minDelay: data.minDelay === undefined ? 30 : data.minDelay,
-    maxDelay: data.maxDelay === undefined ? 110 : data.maxDelay,
-    random: data.random,
-    replace: data.replaceExisting === true,
-  });
+  let primaryError;
+  try {
+    await typeVisible(page, resolved.selector, text, {
+      context: resolved.context,
+      target: resolved.handle,
+      detectState: data.detectState,
+      minDelay: data.minDelay === undefined ? 30 : data.minDelay,
+      maxDelay: data.maxDelay === undefined ? 110 : data.maxDelay,
+      random: data.random,
+      replace: data.replaceExisting === true,
+    });
+  } catch (error) {
+    primaryError = error;
+    throw error;
+  } finally {
+    await disposeResolved(resolved, primaryError);
+  }
   return resolved;
 }
 
 module.exports = {
+  assertAction,
   clickAction,
+  disposeResolved,
   getActionPolicy,
   interactionOptions,
   resolveAction,

--- a/lib/selectors/actions.js
+++ b/lib/selectors/actions.js
@@ -71,9 +71,5 @@ module.exports = Object.freeze({
       '[data-view-name="profile-component-entity"] button[aria-label*="Endorse"]',
       'div[data-view-name="profile-component-entity"] button',
     ],
-    success: [
-      'main button[aria-label^="Remove endorsement"]',
-      '[data-view-name="profile-component-entity"] button[aria-pressed="true"]',
-    ],
   }),
 });

--- a/test/core/selector-resolver.test.js
+++ b/test/core/selector-resolver.test.js
@@ -46,6 +46,222 @@ test("resolveSelector returns the first matching visible candidate", async () =>
   assert.equal(result.handle, visible);
 });
 
+test("resolveSelector skips an earlier hidden match for the same candidate", async () => {
+  const hidden = handle(false);
+  const visible = handle(true);
+  const page = {
+    frames: () => [],
+    url: () => "https://www.linkedin.com/in/example/recent-activity/all/",
+    async $() {
+      return hidden;
+    },
+    async $$() {
+      return [hidden, visible];
+    },
+  };
+
+  const result = await resolveSelector(page, {
+    workflow: "like",
+    name: "button",
+    candidates: ['button[aria-label="React Like"]'],
+    visible: true,
+    timeout: 0,
+  });
+
+  assert.equal(result.selector, 'button[aria-label="React Like"]');
+  assert.equal(result.handle, visible);
+});
+
+test("resolveSelector disposes every unselected handle", async () => {
+  const disposed = [];
+  const tracked = (label, visible) => ({
+    async isVisible() {
+      return visible;
+    },
+    async isIntersectingViewport() {
+      return visible;
+    },
+    async dispose() {
+      disposed.push(label);
+    },
+  });
+  const hidden = tracked("hidden", false);
+  const selected = tracked("selected", true);
+  const trailing = tracked("trailing", true);
+  const page = {
+    frames: () => [],
+    url: () => "https://www.linkedin.com/in/example/",
+    async $$() {
+      return [hidden, selected, trailing];
+    },
+  };
+
+  const result = await resolveSelector(page, {
+    workflow: "like",
+    name: "button",
+    candidates: ['button[aria-label="React Like"]'],
+    visible: true,
+    timeout: 0,
+  });
+
+  assert.equal(result.handle, selected);
+  assert.deepEqual(disposed.sort(), ["hidden", "trailing"]);
+});
+
+test("resolveSelector disposes materialized handles when visibility probing fails", async () => {
+  const failure = new Error("CDP session closed unexpectedly");
+  const disposed = [];
+  const broken = {
+    async isVisible() {
+      throw failure;
+    },
+    async dispose() {
+      disposed.push("broken");
+    },
+  };
+  const trailing = {
+    async dispose() {
+      disposed.push("trailing");
+    },
+  };
+  const page = {
+    frames: () => [],
+    url: () => "https://www.linkedin.com/in/example/",
+    async $$() {
+      return [broken, trailing];
+    },
+  };
+
+  await assert.rejects(
+    resolveSelector(page, {
+      workflow: "like",
+      name: "button",
+      candidates: ['button[aria-label="React Like"]'],
+      visible: true,
+      timeout: 0,
+    }),
+    failure
+  );
+  assert.deepEqual(disposed.sort(), ["broken", "trailing"]);
+});
+
+test("resolveSelector can return a rendered offscreen action target", async () => {
+  const offscreen = {
+    async isIntersectingViewport() {
+      return false;
+    },
+    async boundingBox() {
+      return { x: 20, y: 1350, width: 80, height: 40 };
+    },
+  };
+  const page = {
+    frames: () => [],
+    url: () => "https://www.linkedin.com/in/example/recent-activity/all/",
+    async $$() {
+      return [offscreen];
+    },
+  };
+
+  const result = await resolveSelector(page, {
+    workflow: "like",
+    name: "button",
+    candidates: ['button[aria-label="React Like"]'],
+    visible: true,
+    allowOffscreen: true,
+    timeout: 0,
+  });
+
+  assert.equal(result.handle, offscreen);
+});
+
+test("resolveSelector rejects a CSS-hidden control with geometry", async () => {
+  const hidden = {
+    async isVisible() {
+      return false;
+    },
+    async isIntersectingViewport() {
+      return true;
+    },
+    async boundingBox() {
+      return { x: 20, y: 20, width: 80, height: 40 };
+    },
+  };
+  const page = {
+    frames: () => [],
+    url: () => "https://www.linkedin.com/in/example/recent-activity/all/",
+    async $$() {
+      return [hidden];
+    },
+  };
+
+  await assert.rejects(
+    resolveSelector(page, {
+      workflow: "like",
+      name: "button",
+      candidates: ['button[aria-label="React Like"]'],
+      visible: true,
+      allowOffscreen: true,
+      timeout: 0,
+    }),
+    (error) => error.code === "SELECTOR_NOT_FOUND"
+  );
+});
+
+test("resolveSelector preserves unexpected handle visibility failures", async () => {
+  const failure = new Error("CDP session closed unexpectedly");
+  const handles = [
+    {
+      async isVisible() {
+        throw failure;
+      },
+      async isIntersectingViewport() {
+        return true;
+      },
+    },
+    {
+      async isVisible() {
+        return true;
+      },
+      async isIntersectingViewport() {
+        throw failure;
+      },
+    },
+    {
+      async isVisible() {
+        return true;
+      },
+      async isIntersectingViewport() {
+        return false;
+      },
+      async boundingBox() {
+        throw failure;
+      },
+    },
+  ];
+
+  for (const handle of handles) {
+    const page = {
+      frames: () => [],
+      url: () => "https://www.linkedin.com/in/example/",
+      async $$() {
+        return [handle];
+      },
+    };
+
+    await assert.rejects(
+      resolveSelector(page, {
+        workflow: "like",
+        name: "button",
+        candidates: ['button[aria-label="React Like"]'],
+        visible: true,
+        allowOffscreen: true,
+        timeout: 0,
+      }),
+      failure
+    );
+  }
+});
+
 test("resolveSelector searches child frames", async () => {
   const target = handle();
   const frame = context({ "main h2": target });
@@ -65,6 +281,53 @@ test("resolveSelector searches child frames", async () => {
   assert.equal(result.handle, target);
 });
 
+test("resolveSelector skips detached child frames and finds a stable frame", async () => {
+  const target = handle();
+  const detachedFrame = {
+    async $() {
+      throw new Error("Attempted to use detached Frame 'stale-frame'");
+    },
+  };
+  const stableFrame = context({ "main h2": target });
+  const page = Object.assign(context(), {
+    frames: () => [page, detachedFrame, stableFrame],
+    url: () => "https://www.linkedin.com/in/example/",
+  });
+
+  const result = await resolveSelector(page, {
+    workflow: "profile",
+    name: "name",
+    candidates: ["main h2"],
+    timeout: 0,
+  });
+
+  assert.equal(result.context, stableFrame);
+  assert.equal(result.handle, target);
+});
+
+test("resolveSelector preserves unexpected child-frame failures", async () => {
+  const failure = new Error("CDP session closed unexpectedly");
+  const frame = {
+    async $() {
+      throw failure;
+    },
+  };
+  const page = Object.assign(context(), {
+    frames: () => [page, frame],
+    url: () => "https://www.linkedin.com/in/example/",
+  });
+
+  await assert.rejects(
+    resolveSelector(page, {
+      workflow: "profile",
+      name: "name",
+      candidates: ["main h2"],
+      timeout: 0,
+    }),
+    failure
+  );
+});
+
 test("resolveSelector retries until a candidate appears", async () => {
   let attempts = 0;
   const target = handle();
@@ -81,7 +344,7 @@ test("resolveSelector retries until a candidate appears", async () => {
     workflow: "feed",
     name: "root",
     candidates: ["main"],
-    timeout: 30,
+    timeout: 1000,
     interval: 1,
   });
 

--- a/test/interactions/browser-input.test.js
+++ b/test/interactions/browser-input.test.js
@@ -62,6 +62,39 @@ test("clickVisible falls back to native mouse coordinates", async () => {
   ]);
 });
 
+test("clickVisible scrolls an offscreen target before native coordinates", async () => {
+  const calls = [];
+  let scrolled = false;
+  const target = {
+    async scrollIntoView() {
+      scrolled = true;
+      calls.push(["scroll"]);
+    },
+    async boundingBox() {
+      assert.equal(scrolled, true);
+      return { x: 10, y: 20, width: 40, height: 20 };
+    },
+  };
+  const page = {
+    mouse: {
+      async move(x, y) {
+        calls.push(["move", x, y]);
+      },
+      async click(x, y) {
+        calls.push(["click", x, y]);
+      },
+    },
+  };
+
+  await clickVisible(page, target, { detectState: readyState, delay: 0 });
+
+  assert.deepEqual(calls, [
+    ["scroll"],
+    ["move", 30, 30],
+    ["click", 30, 30],
+  ]);
+});
+
 test("clickVisible uses native coordinates for a child-frame target", async () => {
   const calls = [];
   const target = {

--- a/test/selectors/registry.test.js
+++ b/test/selectors/registry.test.js
@@ -48,7 +48,7 @@ test("current semantic action selectors precede legacy fallbacks", () => {
     "composeRoot", "editor", "open", "send",
   ]);
   assert.deepEqual(Object.keys(actions.like).sort(), ["button", "success"]);
-  assert.deepEqual(Object.keys(actions.endorse).sort(), ["button", "success"]);
+  assert.deepEqual(Object.keys(actions.endorse), ["button"]);
   assert.deepEqual(Object.keys(salesNavigator).sort(), ["filters", "results"]);
   assert.deepEqual(Object.keys(salesNavigator.results).sort(), ["item", "list"]);
   assert.match(actions.connect.primary[0], /aria-label/);

--- a/test/workflows/mutations.test.js
+++ b/test/workflows/mutations.test.js
@@ -6,6 +6,7 @@ const message = require("../../lib/linkedin/linkedin.message.service");
 const { waitForMessageSent } = message;
 const like = require("../../lib/linkedin/linkedin.like.service");
 const endorse = require("../../lib/linkedin/linkedin.endorse.service");
+const { typeAction } = require("../../lib/linkedin/mutation-runtime");
 
 function element(text = "") {
   return {
@@ -14,6 +15,27 @@ function element(text = "") {
     },
     async boundingBox() {
       return { x: 1, y: 2, width: 10, height: 10 };
+    },
+  };
+}
+
+function endorsementControl(skill, { transition = true } = {}) {
+  let label = `Endorse ${skill}`;
+  return {
+    async evaluate(callback) {
+      return callback({
+        getAttribute(name) {
+          if (name === "aria-label") return label;
+          if (name === "aria-pressed") return "false";
+          return null;
+        },
+      });
+    },
+    async boundingBox() {
+      return { x: 1, y: 2, width: 10, height: 10 };
+    },
+    async onClick() {
+      if (transition) label = `Endorsed ${skill}`;
     },
   };
 }
@@ -178,8 +200,10 @@ function mutationPage(selectors = {}) {
       calls.push(["query", selector]);
       return selectors[selector] || null;
     },
-    async $$() {
-      return [];
+    async $$(selector) {
+      const match = selectors[selector];
+      if (Array.isArray(match)) return match;
+      return match ? [match] : [];
     },
     async evaluate() {
       return {
@@ -208,6 +232,9 @@ function mutationPage(selectors = {}) {
     cursor: {
       async click(target) {
         calls.push(["click", target]);
+        if (target && typeof target.onClick === "function") {
+          await target.onClick();
+        }
       },
     },
     mouse: {
@@ -242,6 +269,47 @@ function recordingPolicy() {
     },
   };
 }
+
+test("typeAction focuses the exact visible handle selected after hidden duplicates", async () => {
+  const calls = [];
+  const hidden = {
+    async isVisible() {
+      return false;
+    },
+    async dispose() {
+      calls.push(["dispose", "hidden"]);
+    },
+  };
+  const visible = {
+    async isVisible() {
+      return true;
+    },
+    async isIntersectingViewport() {
+      return true;
+    },
+    async focus() {
+      calls.push(["focus", "visible"]);
+    },
+    async dispose() {
+      calls.push(["dispose", "visible"]);
+    },
+  };
+  const selector = 'textarea[aria-label="Add a note"]';
+  const page = mutationPage({ [selector]: [hidden, visible] });
+
+  await typeAction(page, "connect", "note", [selector], "hello", {
+    timeout: 0,
+    minDelay: 0,
+    maxDelay: 0,
+  });
+
+  assert.deepEqual(calls, [
+    ["dispose", "hidden"],
+    ["focus", "visible"],
+    ["dispose", "visible"],
+  ]);
+  assert.equal(page.calls.some(([name]) => name === "focus"), false);
+});
 
 test("connect uses the 2026 semantic connect and success selectors", async () => {
   const primary = element();
@@ -594,10 +662,12 @@ test("like and endorse use semantic current selectors and success states", async
       endorse,
       "endorse",
       'main button[aria-label^="Endorse "]',
-      'main button[aria-label^="Remove endorsement"]',
+      'main button[aria-label^="Endorsed "]',
     ],
   ]) {
-    const control = element();
+    const control = operation === "endorse"
+      ? endorsementControl("Analytical Engine")
+      : element();
     const page = mutationPage({
       main: element(),
       [current]: control,
@@ -617,6 +687,90 @@ test("like and endorse use semantic current selectors and success states", async
     );
     assert.deepEqual(policy.calls.at(-1), ["complete", operation]);
   }
+});
+
+test("like accepts a rendered control below the current viewport", async () => {
+  const control = {
+    ...element(),
+    async isIntersectingViewport() {
+      return false;
+    },
+  };
+  const page = mutationPage({
+    main: element(),
+    'button[aria-pressed="false"][aria-label*="Like"]': control,
+    'button[aria-pressed="true"][aria-label*="Like"]': element(),
+  });
+  const policy = recordingPolicy();
+
+  const result = await like(page, { actionPolicy: policy }, {
+    url: "https://www.linkedin.com/in/ada/",
+    confirm: true,
+    timeout: 0,
+    clickDelay: 0,
+  });
+
+  assert.equal(result.status, "completed");
+  assert.equal(page.calls.some(([name, target]) => name === "click" && target === control), true);
+});
+
+test("like disposes both the clicked control and verified success handle", async () => {
+  const disposed = [];
+  const control = {
+    ...element(),
+    async dispose() {
+      disposed.push("control");
+    },
+  };
+  const success = {
+    ...element(),
+    async dispose() {
+      disposed.push("success");
+    },
+  };
+  const page = mutationPage({
+    main: element(),
+    'button[aria-pressed="false"][aria-label*="Like"]': control,
+    'button[aria-pressed="true"][aria-label*="Like"]': success,
+  });
+
+  await like(page, { actionPolicy: recordingPolicy() }, {
+    url: "https://www.linkedin.com/in/ada/",
+    confirm: true,
+    timeout: 0,
+    clickDelay: 0,
+  });
+
+  assert.deepEqual(disposed, ["control", "success"]);
+});
+
+test("endorse rejects an unrelated skill that was already endorsed", async () => {
+  const target = endorsementControl("Target Skill", { transition: false });
+  target.dispose = async () => {
+    throw new Error("Execution context was destroyed during cleanup");
+  };
+  const unrelatedSuccess = element();
+  const page = mutationPage({
+    main: element(),
+    'main button[aria-label^="Endorse "]': target,
+    'main button[aria-label^="Endorsed "]': unrelatedSuccess,
+  });
+  const policy = recordingPolicy();
+
+  await assert.rejects(
+    endorse(page, { actionPolicy: policy }, {
+      url: "https://www.linkedin.com/in/ada/",
+      confirm: true,
+      timeout: 0,
+      clickDelay: 0,
+    }),
+    (error) => error.code === "ENDORSEMENT_NOT_VERIFIED"
+  );
+  assert.deepEqual(policy.calls.at(-1), [
+    "reject",
+    "endorse",
+    "ENDORSEMENT_NOT_VERIFIED",
+  ]);
 });
 
 test("an unconfirmed action never clicks", async () => {


### PR DESCRIPTION
## Summary

LinkedIn action pages can render multiple matching controls, including hidden duplicates, controls below the viewport, and stale child frames. The previous resolver inspected only the first match, so valid Like/Endorse/typing targets could be missed or the wrong control could be focused.

This PR:

- inspects all selector matches while preserving main-page-first context priority
- rejects CSS-hidden controls and permits rendered offscreen action controls
- scrolls before native coordinate clicks
- skips only recognized detached child frames while preserving unexpected failures
- focuses the exact resolved typing handle
- disposes Puppeteer handles without masking the primary operation error
- verifies endorsement success against the exact clicked skill instead of any globally endorsed skill

## Checklist

- [x] Select the first eligible visible match instead of the first DOM match
- [x] Support rendered action controls below the deterministic viewport
- [x] Reject CSS-hidden controls even when geometry exists
- [x] Preserve unexpected visibility, geometry, and child-frame failures
- [x] Dispose selected and unselected Puppeteer handles safely
- [x] Scroll native mouse fallback before calculating coordinates
- [x] Focus the exact resolved handle for keyboard input
- [x] Bind endorsement verification to the clicked skill/control
- [x] Prevent unrelated pre-endorsed skills from satisfying success
- [x] Add regression coverage for selector, click, type, disposal, and mutation workflows
- [x] Run full offline suite: 118 passed, 0 failed, 1 opt-in authenticated live test skipped
- [x] Complete two independent reviews with no Critical or Important findings
- [x] Verify the Nithis Like against the exact activity card in authenticated local Chrome
- [ ] Retest other mutation services live in a separate explicitly approved session

## Live verification

The exact Nithis activity-card Like was completed and verified in the authenticated local macOS Chrome session. It was not repeated after the final code changes to avoid toggling the Like off.

No design/specification Markdown files are included.
