### PR TITLE
Harden weekly LinkedIn selector checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ Local LinkedIn automation through a visible, signed-in Chrome session.
 ## Install
 
 ```sh
-npm install linkout-scraper --save
+npm install github:linkoutapp/linkout-scraper#main --save
 ```
+
+The npm registry release is blocked until npm account 2FA is recovered. Use the GitHub dependency for the current Linkout runtime.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -27,10 +27,8 @@ Local LinkedIn automation through a visible, signed-in Chrome session.
 ## Install
 
 ```sh
-npm install github:linkoutapp/linkout-scraper#main --save
+npm install linkout-scraper --save
 ```
-
-The npm registry release is blocked until npm package publishing access is recovered. Use the GitHub dependency for the current Linkout runtime.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Local LinkedIn automation through a visible, signed-in Chrome session.
 npm install github:linkoutapp/linkout-scraper#main --save
 ```
 
-The npm registry release is blocked until npm account 2FA is recovered. Use the GitHub dependency for the current Linkout runtime.
+The npm registry release is blocked until npm package publishing access is recovered. Use the GitHub dependency for the current Linkout runtime.
 
 ## Usage
 

--- a/lib/helpers/find-page-context.js
+++ b/lib/helpers/find-page-context.js
@@ -66,11 +66,10 @@ async function findMatchingHandle(
   context,
   selector,
   visible,
-  allowOffscreen
+  allowOffscreen,
+  lookupTimeout
 ) {
-  const handles = typeof context.$$ === "function"
-    ? await context.$$(selector)
-    : [await context.$(selector)].filter(Boolean);
+  const handles = await boundedSelectorLookup(context, selector, lookupTimeout);
 
   let selected = null;
   let primaryError;
@@ -93,6 +92,39 @@ async function findMatchingHandle(
   return selected;
 }
 
+function selectorLookupTimeout(timeout, interval) {
+  const values = [timeout, interval]
+    .filter((value) => Number.isFinite(value) && value > 0);
+  return Math.max(1, Math.min(1000, ...values));
+}
+
+async function withSelectorLookupTimeout(promise, timeout, selector) {
+  let timer;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timer = setTimeout(() => {
+          reject(new LinkoutError(
+            "SELECTOR_LOOKUP_TIMEOUT",
+            "Selector lookup timed out",
+            { selector, timeout }
+          ));
+        }, timeout);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function boundedSelectorLookup(context, selector, timeout) {
+  const lookup = typeof context.$$ === "function"
+    ? context.$$(selector)
+    : context.$(selector).then((handle) => [handle].filter(Boolean));
+  return withSelectorLookupTimeout(lookup, timeout, selector);
+}
+
 async function resolveSelector(
   page,
   {
@@ -110,6 +142,7 @@ async function resolveSelector(
   }
 
   const startedAt = Date.now();
+  const lookupTimeout = selectorLookupTimeout(timeout, interval);
 
   do {
     const frames = typeof page.frames === "function" ? page.frames() : [];
@@ -122,14 +155,21 @@ async function resolveSelector(
             context,
             selector,
             visible,
-            allowOffscreen
+            allowOffscreen,
+            lookupTimeout
           );
           if (handle) {
             return { context, selector, handle };
           }
         }
       } catch (error) {
-        if (context === page || !isDetachedContextError(error)) {
+        if (
+          context === page ||
+          (
+            !isDetachedContextError(error) &&
+            error.code !== "SELECTOR_LOOKUP_TIMEOUT"
+          )
+        ) {
           throw error;
         }
       }

--- a/lib/helpers/load-cursor.js
+++ b/lib/helpers/load-cursor.js
@@ -1,6 +1,7 @@
 async function loadCursor(page) {
   const { createCursor } = require("ghost-cursor");
   page.cursor = await createCursor(page, undefined, false);
+  return page.cursor;
 }
 
 module.exports = loadCursor;

--- a/lib/helpers/navigate-linkedin.js
+++ b/lib/helpers/navigate-linkedin.js
@@ -1,0 +1,20 @@
+const DEFAULT_NAVIGATION_TIMEOUT = 60000;
+
+function navigationTimeout(data = {}) {
+  return data.navigationTimeout === undefined
+    ? DEFAULT_NAVIGATION_TIMEOUT
+    : data.navigationTimeout;
+}
+
+async function navigateLinkedIn(page, url, data = {}) {
+  return page.goto(url, {
+    waitUntil: "domcontentloaded",
+    timeout: navigationTimeout(data),
+  });
+}
+
+module.exports = {
+  DEFAULT_NAVIGATION_TIMEOUT,
+  navigateLinkedIn,
+  navigationTimeout,
+};

--- a/lib/interactions/browser-input.js
+++ b/lib/interactions/browser-input.js
@@ -21,15 +21,26 @@ async function clickVisible(
     detectState = defaultDetectPageState,
     delay = 0,
     mouseSteps = 12,
+    postDelay = 0,
     preferNative = false,
+    requireCursor = false,
+    sleep: wait = sleep,
   } = {}
 ) {
   await assertPageReady(page, detectState);
-  await sleep(delay);
+  if (Number(delay) > 0) {
+    await wait(delay);
+  }
 
   if (!preferNative && page.cursor && typeof page.cursor.click === "function") {
     await page.cursor.click(target);
   } else {
+    if (!preferNative && requireCursor) {
+      throw new LinkoutError(
+        "GHOST_CURSOR_REQUIRED",
+        "Ghost cursor is required for top-level clicks"
+      );
+    }
     if (target && typeof target.scrollIntoView === "function") {
       await target.scrollIntoView();
     }
@@ -48,6 +59,9 @@ async function clickVisible(
     await page.mouse.click(x, y);
   }
 
+  if (Number(postDelay) > 0) {
+    await wait(postDelay);
+  }
   await assertPageReady(page, detectState);
 }
 
@@ -60,8 +74,10 @@ async function typeVisible(
     detectState = defaultDetectPageState,
     minDelay = 30,
     maxDelay = 110,
+    postDelay = 0,
     random = Math.random,
     replace = false,
+    sleep: wait = sleep,
     target,
   } = {}
 ) {
@@ -83,6 +99,9 @@ async function typeVisible(
   for (const character of [...String(text || "")]) {
     const delay = boundedRandom(minDelay, maxDelay, random);
     await page.keyboard.type(character, { delay });
+  }
+  if (Number(postDelay) > 0) {
+    await wait(postDelay);
   }
   await assertPageReady(page, detectState);
 }

--- a/lib/interactions/browser-input.js
+++ b/lib/interactions/browser-input.js
@@ -1,5 +1,6 @@
 const LinkoutError = require("../errors/linkout-error");
 const { detectPageState: defaultDetectPageState } = require("../browser/detect-page-state");
+const defaultLoadCursor = require("../helpers/load-cursor");
 const { boundedRandom, sleep } = require("./timing");
 
 async function assertPageReady(page, detectState) {
@@ -24,12 +25,22 @@ async function clickVisible(
     postDelay = 0,
     preferNative = false,
     requireCursor = false,
+    loadCursor = defaultLoadCursor,
     sleep: wait = sleep,
   } = {}
 ) {
   await assertPageReady(page, detectState);
   if (Number(delay) > 0) {
     await wait(delay);
+  }
+
+  if (
+    !preferNative &&
+    requireCursor &&
+    !(page.cursor && typeof page.cursor.click === "function") &&
+    typeof loadCursor === "function"
+  ) {
+    await loadCursor(page);
   }
 
   if (!preferNative && page.cursor && typeof page.cursor.click === "function") {

--- a/lib/linkedin/linkedin.accepted.connection.request.service.js
+++ b/lib/linkedin/linkedin.accepted.connection.request.service.js
@@ -1,4 +1,5 @@
 const { findFirstSelector, findPageContext } = require("../helpers/find-page-context");
+const { navigateLinkedIn } = require("../helpers/navigate-linkedin");
 const selectors = require("../selectors/read-only");
 
 function normalizeConnections(rows) {
@@ -27,7 +28,10 @@ function normalizeConnections(rows) {
 }
 
 async function acceptedConnections(page) {
-  await page.goto("https://www.linkedin.com/mynetwork/invite-connect/connections/");
+  await navigateLinkedIn(
+    page,
+    "https://www.linkedin.com/mynetwork/invite-connect/connections/"
+  );
 
   const context = await findPageContext(page, selectors.connections.root);
   if (!context) {

--- a/lib/linkedin/linkedin.connect.service.js
+++ b/lib/linkedin/linkedin.connect.service.js
@@ -1,6 +1,7 @@
 const scrapeProfileData = require("../helpers/scrapeProfileData");
 const generateMessage = require("../helpers/generateMessage");
 const LinkoutError = require("../errors/linkout-error");
+const { navigateLinkedIn } = require("../helpers/navigate-linkedin");
 const selectors = require("../selectors/actions").connect;
 const { clickVisible } = require("../interactions/browser-input");
 const {
@@ -49,17 +50,14 @@ async function openConnectionDialog(page, data) {
 
 async function verifyConnectionSuccess(page, url, data) {
   if (url && isCustomInviteHref(page.url())) {
-    await page.goto(url, {
-      waitUntil: "domcontentloaded",
-      timeout: data.navigationTimeout === undefined ? 60000 : data.navigationTimeout,
-    });
+    await navigateLinkedIn(page, url, data);
   }
   await assertAction(page, "connect", "success", selectors.success, data);
 }
 
 async function connect(page, cdp, data = {}) {
   const { url, message, confirm = false } = data;
-  await page.goto(url);
+  await navigateLinkedIn(page, url, data);
 
   const profileData = await scrapeProfileData(page);
   if (!profileData || !profileData.fullName) {

--- a/lib/linkedin/linkedin.connect.service.js
+++ b/lib/linkedin/linkedin.connect.service.js
@@ -2,21 +2,59 @@ const scrapeProfileData = require("../helpers/scrapeProfileData");
 const generateMessage = require("../helpers/generateMessage");
 const LinkoutError = require("../errors/linkout-error");
 const selectors = require("../selectors/actions").connect;
+const { clickVisible } = require("../interactions/browser-input");
 const {
   assertAction,
   clickAction,
+  disposeResolved,
   getActionPolicy,
+  interactionOptions,
+  resolveAction,
   typeAction,
 } = require("./mutation-runtime");
 
+function isCustomInviteHref(href) {
+  return /\/preload\/custom-invite\//i.test(String(href || ""));
+}
+
+async function activateConnectionTarget(page, name, candidates, data) {
+  const resolved = await resolveAction(page, "connect", name, candidates, data);
+  let primaryError;
+  try {
+    await clickVisible(page, resolved.handle, {
+      ...interactionOptions(data),
+      preferNative: resolved.context !== page,
+    });
+  } catch (error) {
+    primaryError = error;
+    throw error;
+  } finally {
+    await disposeResolved(resolved, primaryError);
+  }
+}
+
+async function openPrimaryConnectionDialog(page, data) {
+  return activateConnectionTarget(page, "primary", selectors.primary, data);
+}
+
 async function openConnectionDialog(page, data) {
   try {
-    return await clickAction(page, "connect", "primary", selectors.primary, data);
+    return await openPrimaryConnectionDialog(page, data);
   } catch (error) {
     if (error.code !== "SELECTOR_NOT_FOUND") throw error;
     await clickAction(page, "connect", "moreActions", selectors.moreActions, data);
-    return clickAction(page, "connect", "menuItem", selectors.menuItem, data);
+    return activateConnectionTarget(page, "menuItem", selectors.menuItem, data);
   }
+}
+
+async function verifyConnectionSuccess(page, url, data) {
+  if (url && isCustomInviteHref(page.url())) {
+    await page.goto(url, {
+      waitUntil: "domcontentloaded",
+      timeout: data.navigationTimeout === undefined ? 60000 : data.navigationTimeout,
+    });
+  }
+  await assertAction(page, "connect", "success", selectors.success, data);
 }
 
 async function connect(page, cdp, data = {}) {
@@ -50,7 +88,7 @@ async function connect(page, cdp, data = {}) {
       );
     }
     await clickAction(page, "connect", "send", selectors.send, data);
-    await assertAction(page, "connect", "success", selectors.success, data);
+    await verifyConnectionSuccess(page, url, data);
     await transaction.complete();
     return { status: "sent", profileData };
   } catch (error) {
@@ -60,4 +98,6 @@ async function connect(page, cdp, data = {}) {
 }
 
 module.exports = connect;
+module.exports.isCustomInviteHref = isCustomInviteHref;
 module.exports.openConnectionDialog = openConnectionDialog;
+module.exports.verifyConnectionSuccess = verifyConnectionSuccess;

--- a/lib/linkedin/linkedin.connection.status.js
+++ b/lib/linkedin/linkedin.connection.status.js
@@ -5,13 +5,18 @@ function classifyConnectionStatus(signals) {
   const texts = Array.isArray(signals.texts) ? signals.texts : [];
   const labels = Array.isArray(signals.labels) ? signals.labels : [];
   const buttons = Array.isArray(signals.buttons) ? signals.buttons : [];
+  const controls = [...labels, ...buttons];
+
+  if (controls.some((text) => /\bpending\b/i.test(text))) {
+    return "Pending";
+  }
+
+  if (controls.some((text) => /\b(?:invite\b.*\bconnect|connect)\b/i.test(text))) {
+    return "Not connected";
+  }
 
   if (texts.some((text) => /\b1st\b/i.test(text))) {
     return "Connected";
-  }
-
-  if ([...labels, ...buttons].some((text) => /\bpending\b/i.test(text))) {
-    return "Pending";
   }
 
   return "Not connected";

--- a/lib/linkedin/linkedin.connection.status.js
+++ b/lib/linkedin/linkedin.connection.status.js
@@ -1,4 +1,5 @@
 const { findPageContext } = require("../helpers/find-page-context");
+const { navigateLinkedIn } = require("../helpers/navigate-linkedin");
 const selectors = require("../selectors/read-only");
 
 function classifyConnectionStatus(signals) {
@@ -25,7 +26,7 @@ function classifyConnectionStatus(signals) {
 async function connectionStatus(page, cdp, data) {
   const { user } = data;
 
-  await page.goto(user);
+  await navigateLinkedIn(page, user, data);
 
   const context = await findPageContext(page, selectors.profile.root);
   if (!context) {
@@ -34,11 +35,14 @@ async function connectionStatus(page, cdp, data) {
 
   const signals = await context.evaluate(() => {
     const primary = document.querySelector("main") || document;
+    const topCard = Array.from(
+      primary.querySelectorAll('[data-view-name="profile-top-card"], section')
+    ).find((section) => section.querySelector("h1, h2")) || primary;
     const textElements = Array.from(
-      primary.querySelectorAll("p, span")
+      topCard.querySelectorAll("p, span")
     ).slice(0, 250);
     const controls = Array.from(
-      primary.querySelectorAll("button, a[aria-label], [role='button']")
+      topCard.querySelectorAll("button, a[aria-label], [role='button']")
     ).slice(0, 150);
 
     return {

--- a/lib/linkedin/linkedin.endorse.service.js
+++ b/lib/linkedin/linkedin.endorse.service.js
@@ -1,5 +1,6 @@
 const createLinkedinUrl = require("../helpers/create.linkedin.url");
 const LinkoutError = require("../errors/linkout-error");
+const { navigateLinkedIn } = require("../helpers/navigate-linkedin");
 const { clickVisible } = require("../interactions/browser-input");
 const { sleep } = require("../interactions/timing");
 const selectors = require("../selectors/actions").endorse;
@@ -58,7 +59,7 @@ async function waitForEndorsement(
 
 async function endorse(page, cdp, data = {}) {
   const target = await createLinkedinUrl(data.url, 3);
-  await page.goto(target);
+  await navigateLinkedIn(page, target, data);
   const transaction = await getActionPolicy(cdp, data).begin({
     operation: "endorse",
     target,

--- a/lib/linkedin/linkedin.like.service.js
+++ b/lib/linkedin/linkedin.like.service.js
@@ -1,4 +1,5 @@
 const createLinkedinUrl = require("../helpers/create.linkedin.url");
+const { navigateLinkedIn } = require("../helpers/navigate-linkedin");
 const selectors = require("../selectors/actions").like;
 const {
   assertAction,
@@ -8,7 +9,7 @@ const {
 
 async function like(page, cdp, data = {}) {
   const target = await createLinkedinUrl(data.url, 2);
-  await page.goto(target);
+  await navigateLinkedIn(page, target, data);
   const transaction = await getActionPolicy(cdp, data).begin({
     operation: "like",
     target,

--- a/lib/linkedin/linkedin.message.service.js
+++ b/lib/linkedin/linkedin.message.service.js
@@ -1,5 +1,6 @@
 const generateMessage = require("../helpers/generateMessage");
 const LinkoutError = require("../errors/linkout-error");
+const { navigateLinkedIn } = require("../helpers/navigate-linkedin");
 const selectors = require("../selectors/actions").message;
 const { detectPageState } = require("../browser/detect-page-state");
 const { clickVisible, typeVisible } = require("../interactions/browser-input");
@@ -385,7 +386,7 @@ async function waitForMessageSent(
 
 async function message(page, cdp, data = {}) {
   const { url, message: template, confirm = false } = data;
-  await page.goto(url);
+  await navigateLinkedIn(page, url, data);
   const target = await resolveProfileMessageTarget(page, url, data);
   const { profileData } = target;
 
@@ -398,9 +399,11 @@ async function message(page, cdp, data = {}) {
   });
 
   try {
-    await page.goto(target.href, {
-      waitUntil: "domcontentloaded",
-      timeout: data.navigationTimeout === undefined ? 30000 : data.navigationTimeout,
+    await navigateLinkedIn(page, target.href, {
+      ...data,
+      navigationTimeout: data.navigationTimeout === undefined
+        ? 30000
+        : data.navigationTimeout,
     });
     const compose = await verifyComposeRecipient(page, target, data);
     const renderedMessage = generateMessage(String(template || ""), profileData);

--- a/lib/linkedin/linkedin.messages.from.chat.service.js
+++ b/lib/linkedin/linkedin.messages.from.chat.service.js
@@ -2,6 +2,7 @@ const {
   findFirstSelector,
   waitForPageContext,
 } = require("../helpers/find-page-context");
+const { navigateLinkedIn } = require("../helpers/navigate-linkedin");
 const selectors = require("../selectors/read-only");
 
 function extractUserName(linkedinProfileUrl) {
@@ -110,7 +111,7 @@ async function messagesFromChat(page, cdp, data) {
     ? user
     : `https://www.linkedin.com/messaging/compose/?connId=${userName}`;
 
-  await page.goto(destination);
+  await navigateLinkedIn(page, destination, data);
 
   const rootContext = await waitForPageContext(
     page,

--- a/lib/linkedin/linkedin.visit.service.js
+++ b/lib/linkedin/linkedin.visit.service.js
@@ -1,11 +1,12 @@
 const scrapeProfileData = require("../helpers/scrapeProfileData");
 const timer = require("../helpers/timer");
 const LinkoutError = require("../errors/linkout-error");
+const { navigateLinkedIn } = require("../helpers/navigate-linkedin");
 
 async function visit(page, cdp, data) {
   const { url } = data;
 
-  await page.goto(url);
+  await navigateLinkedIn(page, url, data);
 
   await timer(2000);
 

--- a/lib/linkedin/mutation-runtime.js
+++ b/lib/linkedin/mutation-runtime.js
@@ -14,6 +14,11 @@ function interactionOptions(data = {}) {
       data.clickDelay === undefined
         ? jitteredDelay(450, { jitter: 200 })
         : data.clickDelay,
+    postDelay:
+      data.clickPostDelay === undefined
+        ? jitteredDelay(350, { jitter: 150, random: data.random })
+        : data.clickPostDelay,
+    requireCursor: data.requireCursor === undefined ? true : data.requireCursor,
   };
 }
 
@@ -76,6 +81,10 @@ async function typeAction(page, workflow, name, candidates, text, data = {}) {
       detectState: data.detectState,
       minDelay: data.minDelay === undefined ? 30 : data.minDelay,
       maxDelay: data.maxDelay === undefined ? 110 : data.maxDelay,
+      postDelay:
+        data.typePostDelay === undefined
+          ? jitteredDelay(300, { jitter: 150, random: data.random })
+          : data.typePostDelay,
       random: data.random,
       replace: data.replaceExisting === true,
     });

--- a/lib/selectors/actions.js
+++ b/lib/selectors/actions.js
@@ -1,15 +1,20 @@
 module.exports = Object.freeze({
   connect: Object.freeze({
     primary: [
-      'main button[aria-label*="Invite"][aria-label*="connect"]',
-      'main button[aria-label^="Connect"]',
-      'section.artdeco-card button[aria-label*="Invite"]',
+      'main [data-view-name="profile-top-card"] a[href*="/preload/custom-invite/"]',
+      'main section:has(h1) a[href*="/preload/custom-invite/"]',
+      'main section:has(h2) a[href*="/preload/custom-invite/"]',
+      'main [data-view-name="profile-top-card"] button[aria-label*="Invite"][aria-label*="connect"]',
     ],
     moreActions: [
+      'main [data-view-name="profile-top-card"] button[aria-label="More"]',
+      'main section:has(h1) button[aria-label="More"]',
+      'main section:has(h2) button[aria-label="More"]',
       'main button[aria-label*="More actions"]',
       'section.artdeco-card button[aria-label*="More actions"]',
     ],
     menuItem: [
+      '[role="menuitem"][href*="/preload/custom-invite/"]',
       '[role="menuitem"][aria-label*="connect"]',
       '[role="menu"] [aria-label*="to connect"]',
       'div[aria-label*="to connect"]',
@@ -24,10 +29,13 @@ module.exports = Object.freeze({
       'button[aria-label*="personalize invitation"]',
     ],
     send: [
+      '[role="dialog"] button[type="submit"]:not(:disabled)',
+      '.artdeco-modal button[type="submit"]:not(:disabled)',
       'button[aria-label*="Send invitation"]:not(:disabled)',
       'button[aria-label*="Send without a note"]:not(:disabled)',
     ],
     success: [
+      'main [aria-label*="Pending"][aria-label*="invitation"]',
       'main button[aria-label*="Pending"]',
       'main [aria-label*="invitation is pending"]',
     ],

--- a/test/core/selector-resolver.test.js
+++ b/test/core/selector-resolver.test.js
@@ -305,6 +305,31 @@ test("resolveSelector skips detached child frames and finds a stable frame", asy
   assert.equal(result.handle, target);
 });
 
+test("resolveSelector skips child frames with stalled selector lookup", async () => {
+  const target = handle();
+  const stalledFrame = {
+    async $$() {
+      return new Promise(() => {});
+    },
+  };
+  const stableFrame = context({ "main h2": target });
+  const page = Object.assign(context(), {
+    frames: () => [page, stalledFrame, stableFrame],
+    url: () => "https://www.linkedin.com/in/example/",
+  });
+
+  const result = await resolveSelector(page, {
+    workflow: "profile",
+    name: "name",
+    candidates: ["main h2"],
+    timeout: 50,
+    interval: 1,
+  });
+
+  assert.equal(result.context, stableFrame);
+  assert.equal(result.handle, target);
+});
+
 test("resolveSelector preserves unexpected child-frame failures", async () => {
   const failure = new Error("CDP session closed unexpectedly");
   const frame = {

--- a/test/helpers/navigate-linkedin.test.js
+++ b/test/helpers/navigate-linkedin.test.js
@@ -1,0 +1,31 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  DEFAULT_NAVIGATION_TIMEOUT,
+  navigateLinkedIn,
+  navigationTimeout,
+} = require("../../lib/helpers/navigate-linkedin");
+
+test("LinkedIn navigation defaults to DOMContentLoaded with a bounded timeout", async () => {
+  const calls = [];
+  const page = {
+    async goto(url, options) {
+      calls.push([url, options]);
+    },
+  };
+
+  await navigateLinkedIn(page, "https://www.linkedin.com/in/ada/");
+
+  assert.deepEqual(calls, [
+    [
+      "https://www.linkedin.com/in/ada/",
+      { waitUntil: "domcontentloaded", timeout: DEFAULT_NAVIGATION_TIMEOUT },
+    ],
+  ]);
+});
+
+test("LinkedIn navigation accepts explicit navigation timeout only", () => {
+  assert.equal(navigationTimeout({ navigationTimeout: 30000 }), 30000);
+  assert.equal(navigationTimeout({ timeout: 1 }), DEFAULT_NAVIGATION_TIMEOUT);
+});

--- a/test/interactions/browser-input.test.js
+++ b/test/interactions/browser-input.test.js
@@ -86,10 +86,36 @@ test("clickVisible can require a ghost cursor for top-level clicks", async () =>
         detectState: readyState,
         delay: 0,
         requireCursor: true,
+        loadCursor: async () => {},
       }
     ),
     (error) => error.code === "GHOST_CURSOR_REQUIRED"
   );
+});
+
+test("clickVisible loads a ghost cursor when top-level action clicks require it", async () => {
+  const calls = [];
+  const target = {};
+  const page = {};
+
+  await clickVisible(page, target, {
+    detectState: readyState,
+    delay: 0,
+    requireCursor: true,
+    loadCursor: async (loadedPage) => {
+      calls.push(["load", loadedPage === page]);
+      loadedPage.cursor = {
+        async click(value) {
+          calls.push(["cursor", value === target]);
+        },
+      };
+    },
+  });
+
+  assert.deepEqual(calls, [
+    ["load", true],
+    ["cursor", true],
+  ]);
 });
 
 test("clickVisible waits after a ghost cursor click", async () => {

--- a/test/interactions/browser-input.test.js
+++ b/test/interactions/browser-input.test.js
@@ -62,6 +62,56 @@ test("clickVisible falls back to native mouse coordinates", async () => {
   ]);
 });
 
+test("clickVisible can require a ghost cursor for top-level clicks", async () => {
+  const target = {
+    async boundingBox() {
+      return { x: 10, y: 20, width: 40, height: 20 };
+    },
+  };
+
+  await assert.rejects(
+    clickVisible(
+      {
+        mouse: {
+          async move() {
+            assert.fail("must not use native mouse when cursor is required");
+          },
+          async click() {
+            assert.fail("must not use native mouse when cursor is required");
+          },
+        },
+      },
+      target,
+      {
+        detectState: readyState,
+        delay: 0,
+        requireCursor: true,
+      }
+    ),
+    (error) => error.code === "GHOST_CURSOR_REQUIRED"
+  );
+});
+
+test("clickVisible waits after a ghost cursor click", async () => {
+  const calls = [];
+  const page = {
+    cursor: {
+      async click() {
+        calls.push("click");
+      },
+    },
+  };
+
+  await clickVisible(page, {}, {
+    detectState: readyState,
+    delay: 0,
+    postDelay: 5,
+    sleep: async (milliseconds) => calls.push(["sleep", milliseconds]),
+  });
+
+  assert.deepEqual(calls, ["click", ["sleep", 5]]);
+});
+
 test("clickVisible scrolls an offscreen target before native coordinates", async () => {
   const calls = [];
   let scrolled = false;
@@ -155,6 +205,35 @@ test("typeVisible emits per-character native keyboard input", async () => {
     ["type", "H", { delay: 30 }],
     ["type", "i", { delay: 30 }],
     ["type", "!", { delay: 30 }],
+  ]);
+});
+
+test("typeVisible waits after native keyboard input", async () => {
+  const calls = [];
+  const page = {
+    async focus(selector) {
+      calls.push(["focus", selector]);
+    },
+    keyboard: {
+      async type(value) {
+        calls.push(["type", value]);
+      },
+    },
+  };
+
+  await typeVisible(page, "#editor", "Hi", {
+    detectState: readyState,
+    minDelay: 0,
+    maxDelay: 0,
+    postDelay: 7,
+    sleep: async (milliseconds) => calls.push(["sleep", milliseconds]),
+  });
+
+  assert.deepEqual(calls, [
+    ["focus", "#editor"],
+    ["type", "H"],
+    ["type", "i"],
+    ["sleep", 7],
   ]);
 });
 

--- a/test/interactions/mutation-runtime.test.js
+++ b/test/interactions/mutation-runtime.test.js
@@ -1,0 +1,30 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { interactionOptions } = require("../../lib/linkedin/mutation-runtime");
+
+test("mutation interaction options require ghost cursor and include post-action jitter", () => {
+  const options = interactionOptions({
+    random: () => 0.5,
+  });
+
+  assert.equal(options.requireCursor, true);
+  assert.equal(options.delay >= 250 && options.delay <= 650, true);
+  assert.equal(options.postDelay >= 200 && options.postDelay <= 500, true);
+});
+
+test("mutation interaction options allow explicit test overrides", () => {
+  assert.deepEqual(
+    interactionOptions({
+      clickDelay: 0,
+      clickPostDelay: 0,
+      requireCursor: false,
+    }),
+    {
+      detectState: undefined,
+      delay: 0,
+      postDelay: 0,
+      requireCursor: false,
+    }
+  );
+});

--- a/test/package/readme.test.js
+++ b/test/package/readme.test.js
@@ -26,7 +26,8 @@ test("README follows the Linvo-style package introduction", () => {
   for (const heading of ["Install", "Usage", "Maintainer", "Contributing", "License"]) {
     assert.match(readme, new RegExp(`^## ${heading}$`, "m"));
   }
-  assert.match(readme, /npm install linkout-scraper --save/);
+  assert.match(readme, /npm install github:linkoutapp\/linkout-scraper#main --save/);
+  assert.match(readme, /npm registry release is blocked until npm account 2FA is recovered/);
   assert.match(readme, /Scrape profiles/);
   assert.doesNotMatch(readme, /Sales Nav/i);
   assert.match(readme, /Connection requests/);

--- a/test/package/readme.test.js
+++ b/test/package/readme.test.js
@@ -26,8 +26,7 @@ test("README follows the Linvo-style package introduction", () => {
   for (const heading of ["Install", "Usage", "Maintainer", "Contributing", "License"]) {
     assert.match(readme, new RegExp(`^## ${heading}$`, "m"));
   }
-  assert.match(readme, /npm install github:linkoutapp\/linkout-scraper#main --save/);
-  assert.match(readme, /npm registry release is blocked until npm package publishing access is recovered/);
+  assert.match(readme, /npm install linkout-scraper --save/);
   assert.match(readme, /Scrape profiles/);
   assert.doesNotMatch(readme, /Sales Nav/i);
   assert.match(readme, /Connection requests/);

--- a/test/package/readme.test.js
+++ b/test/package/readme.test.js
@@ -27,7 +27,7 @@ test("README follows the Linvo-style package introduction", () => {
     assert.match(readme, new RegExp(`^## ${heading}$`, "m"));
   }
   assert.match(readme, /npm install github:linkoutapp\/linkout-scraper#main --save/);
-  assert.match(readme, /npm registry release is blocked until npm account 2FA is recovered/);
+  assert.match(readme, /npm registry release is blocked until npm package publishing access is recovered/);
   assert.match(readme, /Scrape profiles/);
   assert.doesNotMatch(readme, /Sales Nav/i);
   assert.match(readme, /Connection requests/);

--- a/test/read-only/connections.test.js
+++ b/test/read-only/connections.test.js
@@ -10,10 +10,12 @@ function connectionsPage(rows) {
 
   return {
     visited: null,
+    navigationOptions: null,
     queriedSelector: null,
     frames: () => [],
-    async goto(url) {
+    async goto(url, options) {
       this.visited = url;
+      this.navigationOptions = options;
     },
     async $(selector) {
       return selector === "main" || selector === currentSelector ? {} : null;
@@ -35,6 +37,10 @@ test("connections use current profile links and remove duplicates", async () => 
   const result = await acceptedConnections(page);
 
   assert.equal(page.queriedSelector, 'main a[href*="/in/"]');
+  assert.deepEqual(page.navigationOptions, {
+    waitUntil: "domcontentloaded",
+    timeout: 60000,
+  });
   assert.deepEqual(result, [
     { name: "Ada Lovelace", url: "https://www.linkedin.com/in/ada/" },
     { name: "Grace Hopper", url: "https://www.linkedin.com/in/grace/" },

--- a/test/read-only/messages.test.js
+++ b/test/read-only/messages.test.js
@@ -24,9 +24,11 @@ function messagingPage(rows, header = { name: "Nithis", img: "avatar.png" }) {
 
   return {
     visited: null,
+    navigationOptions: null,
     frames: () => [frame],
-    async goto(url) {
+    async goto(url, options) {
       this.visited = url;
+      this.navigationOptions = options;
     },
     async $() {
       return null;
@@ -59,6 +61,10 @@ test("message history uses the matching child frame and semantic rows", async ()
   });
 
   assert.match(page.visited, /\/messaging\/compose\/\?connId=ada$/);
+  assert.deepEqual(page.navigationOptions, {
+    waitUntil: "domcontentloaded",
+    timeout: 60000,
+  });
   assert.deepEqual(result, {
     name: "Nithis",
     img: "avatar.png",
@@ -82,6 +88,10 @@ test("message history accepts an existing thread URL without rewriting it", asyn
   });
 
   assert.equal(page.visited, threadUrl);
+  assert.deepEqual(page.navigationOptions, {
+    waitUntil: "domcontentloaded",
+    timeout: 60000,
+  });
   assert.deepEqual(result.values, []);
 });
 

--- a/test/read-only/profile.test.js
+++ b/test/read-only/profile.test.js
@@ -100,6 +100,21 @@ test("connection status reports not connected without either signal", async () =
   );
 });
 
+test("connection status prefers an explicit connect CTA over unrelated first-degree text", async () => {
+  const page = statusPage({
+    texts: ["· 1st", "· 2nd", "Connect"],
+    labels: ["Invite Siddhart Shibiraj to connect"],
+    buttons: ["Connect"],
+  });
+
+  assert.equal(
+    await connectionStatus(page, null, {
+      user: "https://www.linkedin.com/in/siddhartshibiraj/",
+    }),
+    "Not connected"
+  );
+});
+
 test("profile visit reports a structured failure when no member heading exists", async () => {
   const page = profilePage(null);
   page.goto = async () => {};

--- a/test/read-only/profile.test.js
+++ b/test/read-only/profile.test.js
@@ -30,9 +30,11 @@ function profilePage(heading) {
 function statusPage(signals) {
   return {
     visited: null,
+    navigationOptions: null,
     frames: () => [],
-    async goto(url) {
+    async goto(url, options) {
       this.visited = url;
+      this.navigationOptions = options;
     },
     async $(selector) {
       return selector === "main" ? {} : null;
@@ -76,6 +78,10 @@ test("connection status detects a first-degree relationship", async () => {
     }),
     "Connected"
   );
+  assert.deepEqual(page.navigationOptions, {
+    waitUntil: "domcontentloaded",
+    timeout: 60000,
+  });
 });
 
 test("connection status detects a pending invitation", async () => {
@@ -115,14 +121,91 @@ test("connection status prefers an explicit connect CTA over unrelated first-deg
   );
 });
 
+test("connection status ignores connect buttons outside the profile top card", async () => {
+  const page = {
+    visited: null,
+    navigationOptions: null,
+    frames: () => [],
+    async goto(url, options) {
+      this.visited = url;
+      this.navigationOptions = options;
+    },
+    async $(selector) {
+      return selector === "main" ? {} : null;
+    },
+    async evaluate(callback) {
+      const fakeDocument = {
+        querySelector(selector) {
+          return selector === "main" ? this : null;
+        },
+        querySelectorAll(selector) {
+          if (selector === '[data-view-name="profile-top-card"], section') {
+            return [
+              {
+                querySelector(value) {
+                  return value === "h1, h2" ? {} : null;
+                },
+                querySelectorAll(value) {
+                  if (value === "p, span") {
+                    return [{ textContent: "· 1st" }];
+                  }
+                  if (value === "button, a[aria-label], [role='button']") {
+                    return [{ textContent: "Message", getAttribute: () => "" }];
+                  }
+                  return [];
+                },
+              },
+              {
+                querySelector(value) {
+                  return value === "h1, h2" ? {} : null;
+                },
+                querySelectorAll(value) {
+                  if (value === "button, a[aria-label], [role='button']") {
+                    return [{
+                      textContent: "Connect",
+                      getAttribute: () => "Invite Decoy to connect",
+                    }];
+                  }
+                  return [];
+                },
+              },
+            ];
+          }
+          return [];
+        },
+      };
+      global.document = fakeDocument;
+      try {
+        return callback();
+      } finally {
+        delete global.document;
+      }
+    },
+  };
+
+  assert.equal(
+    await connectionStatus(page, null, {
+      user: "https://www.linkedin.com/in/friend/",
+    }),
+    "Connected"
+  );
+});
+
 test("profile visit reports a structured failure when no member heading exists", async () => {
   const page = profilePage(null);
-  page.goto = async () => {};
+  let navigationOptions;
+  page.goto = async (_url, options) => {
+    navigationOptions = options;
+  };
 
   await assert.rejects(
     () => visit(page, null, { url: "https://www.linkedin.com/in/missing/" }),
     (error) => error.code === "PROFILE_NOT_FOUND"
   );
+  assert.deepEqual(navigationOptions, {
+    waitUntil: "domcontentloaded",
+    timeout: 60000,
+  });
 });
 
 test("profile and connection reads propagate unexpected page failures", async () => {

--- a/test/selectors/registry.test.js
+++ b/test/selectors/registry.test.js
@@ -51,7 +51,7 @@ test("current semantic action selectors precede legacy fallbacks", () => {
   ]);
   assert.deepEqual(Object.keys(actions.like).sort(), ["button", "success"]);
   assert.deepEqual(Object.keys(actions.endorse), ["button"]);
-  assert.match(actions.connect.primary[0], /aria-label/);
+  assert.match(actions.connect.primary[0], /href/);
   assert.match(actions.message.editor[0], /role="textbox"/);
   assert.match(actions.like.button[0], /aria-pressed/);
   assert.match(actions.endorse.button[0], /aria-label/);

--- a/test/workflows/mutations.test.js
+++ b/test/workflows/mutations.test.js
@@ -212,8 +212,8 @@ function mutationPage(selectors = {}) {
     frameList: [],
     frames: () => page.frameList,
     url: () => page.currentUrl || "https://www.linkedin.com/feed/",
-    async goto(url) {
-      calls.push(["goto", url]);
+    async goto(url, options) {
+      calls.push(["goto", url, options]);
       page.currentUrl = url;
     },
     async $(selector) {
@@ -481,6 +481,13 @@ test("message waits for Send hydration and verifies a sent event", async () => {
     [
       "https://www.linkedin.com/in/ada/",
       "https://www.linkedin.com/messaging/compose/?recipient=ada-id",
+    ]
+  );
+  assert.deepEqual(
+    page.calls.filter(([name]) => name === "goto").map(([, , options]) => options),
+    [
+      { waitUntil: "domcontentloaded", timeout: 60000 },
+      { waitUntil: "domcontentloaded", timeout: 30000 },
     ]
   );
   assert.equal(

--- a/test/workflows/mutations.test.js
+++ b/test/workflows/mutations.test.js
@@ -19,6 +19,26 @@ function element(text = "") {
   };
 }
 
+function linkElement({ text = "", href = "" } = {}) {
+  return {
+    async evaluate(callback) {
+      return callback({
+        textContent: text,
+        href,
+        getAttribute(name) {
+          return name === "href" ? href : null;
+        },
+      });
+    },
+    async boundingBox() {
+      return { x: 1, y: 2, width: 10, height: 10 };
+    },
+    async onClick(page) {
+      page.currentUrl = href;
+    },
+  };
+}
+
 function endorsementControl(skill, { transition = true } = {}) {
   let label = `Endorse ${skill}`;
   return {
@@ -233,7 +253,7 @@ function mutationPage(selectors = {}) {
       async click(target) {
         calls.push(["click", target]);
         if (target && typeof target.onClick === "function") {
-          await target.onClick();
+          await target.onClick(page);
         }
       },
     },
@@ -318,9 +338,9 @@ test("connect uses the 2026 semantic connect and success selectors", async () =>
   const page = mutationPage({
     main: element(),
     "main h2": element("Ada Lovelace"),
-    'main button[aria-label*="Invite"][aria-label*="connect"]': primary,
-    'button[aria-label*="Send invitation"]:not(:disabled)': send,
-    'main button[aria-label*="Pending"]': pending,
+    'main [data-view-name="profile-top-card"] a[href*="/preload/custom-invite/"]': primary,
+    '[role="dialog"] button[type="submit"]:not(:disabled)': send,
+    'main [aria-label*="Pending"][aria-label*="invitation"]': pending,
   });
   const policy = recordingPolicy();
 
@@ -337,6 +357,78 @@ test("connect uses the 2026 semantic connect and success selectors", async () =>
     [primary, send]
   );
   assert.deepEqual(policy.calls.at(-1), ["complete", "connect"]);
+});
+
+test("connect navigates custom invite anchors before sending without a note", async () => {
+  const primary = linkElement({
+    text: "Connect",
+    href: "https://www.linkedin.com/preload/custom-invite/?vanityName=siddhartshibiraj",
+  });
+  const send = element();
+  const pending = element();
+  const page = mutationPage({
+    main: element(),
+    "main h2": element("Siddhart Shibiraj"),
+    'main [data-view-name="profile-top-card"] a[href*="/preload/custom-invite/"]': primary,
+    '[role="dialog"] button[type="submit"]:not(:disabled)': send,
+    'main [aria-label*="Pending"][aria-label*="invitation"]': pending,
+  });
+
+  const result = await connect(page, { actionPolicy: recordingPolicy() }, {
+    url: "https://www.linkedin.com/in/siddhartshibiraj/",
+    confirm: true,
+    timeout: 0,
+    clickDelay: 0,
+  });
+
+  assert.equal(result.status, "sent");
+  assert.deepEqual(
+    page.calls.filter(([name]) => name === "goto").map(([, url]) => url),
+    [
+      "https://www.linkedin.com/in/siddhartshibiraj/",
+      "https://www.linkedin.com/in/siddhartshibiraj/",
+    ]
+  );
+  assert.equal(page.calls.some(([name, target]) => name === "click" && target === primary), true);
+  assert.equal(page.calls.some(([name, target]) => name === "click" && target === send), true);
+});
+
+test("connect uses the top-card more menu for third-degree custom invites", async () => {
+  const more = element();
+  const menuItem = linkElement({
+    text: "Connect",
+    href: "https://www.linkedin.com/preload/custom-invite/?vanityName=avish-arora-",
+  });
+  const send = element();
+  const pending = element();
+  const page = mutationPage({
+    main: element(),
+    "main h2": element("Avish Arora"),
+    'main section:has(h2) button[aria-label="More"]': more,
+    '[role="menuitem"][href*="/preload/custom-invite/"]': menuItem,
+    '[role="dialog"] button[type="submit"]:not(:disabled)': send,
+    'main [aria-label*="Pending"][aria-label*="invitation"]': pending,
+  });
+
+  const result = await connect(page, { actionPolicy: recordingPolicy() }, {
+    url: "https://www.linkedin.com/in/avish-arora-/",
+    confirm: true,
+    timeout: 0,
+    clickDelay: 0,
+  });
+
+  assert.equal(result.status, "sent");
+  assert.deepEqual(
+    page.calls.filter(([name]) => name === "click").map(([, target]) => target),
+    [more, menuItem, send]
+  );
+  assert.deepEqual(
+    page.calls.filter(([name]) => name === "goto").map(([, url]) => url),
+    [
+      "https://www.linkedin.com/in/avish-arora-/",
+      "https://www.linkedin.com/in/avish-arora-/",
+    ]
+  );
 });
 
 test("message waits for Send hydration and verifies a sent event", async () => {


### PR DESCRIPTION
## Summary
- Bound LinkedIn service navigation to DOMContentLoaded with a fixed timeout so LinkedIn pages cannot stall selector checks on full page load.
- Skip stalled child-frame selector lookups while preserving main-page and unexpected selector failures.
- Scope connection status to the profile top card so suggestion-card Connect buttons do not override real 1st-degree status.
- Auto-load the ghost cursor before required top-level action clicks.

## Checklist
- [x] Add regression coverage for bounded LinkedIn navigation.
- [x] Add regression coverage for stalled child-frame selector lookup.
- [x] Fix connection-status false negatives from suggestion-card Connect buttons.
- [x] Fix action services requiring callers to manually attach ghost cursor.
- [x] Run offline suite: 128 tests, 127 passed, 1 opt-in live skipped, 0 failed.
- [x] Run security audit: npm audit --audit-level=moderate, 0 vulnerabilities.
- [x] Run authenticated live read-only selector smoke.
- [x] Verify live connection status for approved first-degree test profiles.
- [x] Test message action with approved first-degree test profiles through Linkout.
- [x] Test like action where a valid unliked activity control was present.
- [ ] Test connect without note: skipped because approved connect targets were already terminal (connected or pending).
- [ ] Test endorsement action: skipped because no live Endorse controls were present on approved test profiles.

No design/spec Markdown files are included. No personal target names are included.

Superseded by #28.