### PR TITLE
Harden weekly LinkedIn selector checks

### DIFF
--- a/lib/helpers/find-page-context.js
+++ b/lib/helpers/find-page-context.js
@@ -66,11 +66,10 @@ async function findMatchingHandle(
   context,
   selector,
   visible,
-  allowOffscreen
+  allowOffscreen,
+  lookupTimeout
 ) {
-  const handles = typeof context.$$ === "function"
-    ? await context.$$(selector)
-    : [await context.$(selector)].filter(Boolean);
+  const handles = await boundedSelectorLookup(context, selector, lookupTimeout);
 
   let selected = null;
   let primaryError;
@@ -93,6 +92,39 @@ async function findMatchingHandle(
   return selected;
 }
 
+function selectorLookupTimeout(timeout, interval) {
+  const values = [timeout, interval]
+    .filter((value) => Number.isFinite(value) && value > 0);
+  return Math.max(1, Math.min(1000, ...values));
+}
+
+async function withSelectorLookupTimeout(promise, timeout, selector) {
+  let timer;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timer = setTimeout(() => {
+          reject(new LinkoutError(
+            "SELECTOR_LOOKUP_TIMEOUT",
+            "Selector lookup timed out",
+            { selector, timeout }
+          ));
+        }, timeout);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function boundedSelectorLookup(context, selector, timeout) {
+  const lookup = typeof context.$$ === "function"
+    ? context.$$(selector)
+    : context.$(selector).then((handle) => [handle].filter(Boolean));
+  return withSelectorLookupTimeout(lookup, timeout, selector);
+}
+
 async function resolveSelector(
   page,
   {
@@ -110,6 +142,7 @@ async function resolveSelector(
   }
 
   const startedAt = Date.now();
+  const lookupTimeout = selectorLookupTimeout(timeout, interval);
 
   do {
     const frames = typeof page.frames === "function" ? page.frames() : [];
@@ -122,14 +155,21 @@ async function resolveSelector(
             context,
             selector,
             visible,
-            allowOffscreen
+            allowOffscreen,
+            lookupTimeout
           );
           if (handle) {
             return { context, selector, handle };
           }
         }
       } catch (error) {
-        if (context === page || !isDetachedContextError(error)) {
+        if (
+          context === page ||
+          (
+            !isDetachedContextError(error) &&
+            error.code !== "SELECTOR_LOOKUP_TIMEOUT"
+          )
+        ) {
           throw error;
         }
       }

--- a/lib/helpers/load-cursor.js
+++ b/lib/helpers/load-cursor.js
@@ -1,6 +1,7 @@
 async function loadCursor(page) {
   const { createCursor } = require("ghost-cursor");
   page.cursor = await createCursor(page, undefined, false);
+  return page.cursor;
 }
 
 module.exports = loadCursor;

--- a/lib/helpers/navigate-linkedin.js
+++ b/lib/helpers/navigate-linkedin.js
@@ -1,0 +1,20 @@
+const DEFAULT_NAVIGATION_TIMEOUT = 60000;
+
+function navigationTimeout(data = {}) {
+  return data.navigationTimeout === undefined
+    ? DEFAULT_NAVIGATION_TIMEOUT
+    : data.navigationTimeout;
+}
+
+async function navigateLinkedIn(page, url, data = {}) {
+  return page.goto(url, {
+    waitUntil: "domcontentloaded",
+    timeout: navigationTimeout(data),
+  });
+}
+
+module.exports = {
+  DEFAULT_NAVIGATION_TIMEOUT,
+  navigateLinkedIn,
+  navigationTimeout,
+};

--- a/lib/interactions/browser-input.js
+++ b/lib/interactions/browser-input.js
@@ -1,5 +1,6 @@
 const LinkoutError = require("../errors/linkout-error");
 const { detectPageState: defaultDetectPageState } = require("../browser/detect-page-state");
+const defaultLoadCursor = require("../helpers/load-cursor");
 const { boundedRandom, sleep } = require("./timing");
 
 async function assertPageReady(page, detectState) {
@@ -24,12 +25,22 @@ async function clickVisible(
     postDelay = 0,
     preferNative = false,
     requireCursor = false,
+    loadCursor = defaultLoadCursor,
     sleep: wait = sleep,
   } = {}
 ) {
   await assertPageReady(page, detectState);
   if (Number(delay) > 0) {
     await wait(delay);
+  }
+
+  if (
+    !preferNative &&
+    requireCursor &&
+    !(page.cursor && typeof page.cursor.click === "function") &&
+    typeof loadCursor === "function"
+  ) {
+    await loadCursor(page);
   }
 
   if (!preferNative && page.cursor && typeof page.cursor.click === "function") {

--- a/lib/linkedin/linkedin.accepted.connection.request.service.js
+++ b/lib/linkedin/linkedin.accepted.connection.request.service.js
@@ -1,4 +1,5 @@
 const { findFirstSelector, findPageContext } = require("../helpers/find-page-context");
+const { navigateLinkedIn } = require("../helpers/navigate-linkedin");
 const selectors = require("../selectors/read-only");
 
 function normalizeConnections(rows) {
@@ -27,7 +28,10 @@ function normalizeConnections(rows) {
 }
 
 async function acceptedConnections(page) {
-  await page.goto("https://www.linkedin.com/mynetwork/invite-connect/connections/");
+  await navigateLinkedIn(
+    page,
+    "https://www.linkedin.com/mynetwork/invite-connect/connections/"
+  );
 
   const context = await findPageContext(page, selectors.connections.root);
   if (!context) {

--- a/lib/linkedin/linkedin.connect.service.js
+++ b/lib/linkedin/linkedin.connect.service.js
@@ -1,6 +1,7 @@
 const scrapeProfileData = require("../helpers/scrapeProfileData");
 const generateMessage = require("../helpers/generateMessage");
 const LinkoutError = require("../errors/linkout-error");
+const { navigateLinkedIn } = require("../helpers/navigate-linkedin");
 const selectors = require("../selectors/actions").connect;
 const { clickVisible } = require("../interactions/browser-input");
 const {
@@ -49,17 +50,14 @@ async function openConnectionDialog(page, data) {
 
 async function verifyConnectionSuccess(page, url, data) {
   if (url && isCustomInviteHref(page.url())) {
-    await page.goto(url, {
-      waitUntil: "domcontentloaded",
-      timeout: data.navigationTimeout === undefined ? 60000 : data.navigationTimeout,
-    });
+    await navigateLinkedIn(page, url, data);
   }
   await assertAction(page, "connect", "success", selectors.success, data);
 }
 
 async function connect(page, cdp, data = {}) {
   const { url, message, confirm = false } = data;
-  await page.goto(url);
+  await navigateLinkedIn(page, url, data);
 
   const profileData = await scrapeProfileData(page);
   if (!profileData || !profileData.fullName) {

--- a/lib/linkedin/linkedin.connection.status.js
+++ b/lib/linkedin/linkedin.connection.status.js
@@ -1,4 +1,5 @@
 const { findPageContext } = require("../helpers/find-page-context");
+const { navigateLinkedIn } = require("../helpers/navigate-linkedin");
 const selectors = require("../selectors/read-only");
 
 function classifyConnectionStatus(signals) {
@@ -25,7 +26,7 @@ function classifyConnectionStatus(signals) {
 async function connectionStatus(page, cdp, data) {
   const { user } = data;
 
-  await page.goto(user);
+  await navigateLinkedIn(page, user, data);
 
   const context = await findPageContext(page, selectors.profile.root);
   if (!context) {
@@ -34,11 +35,14 @@ async function connectionStatus(page, cdp, data) {
 
   const signals = await context.evaluate(() => {
     const primary = document.querySelector("main") || document;
+    const topCard = Array.from(
+      primary.querySelectorAll('[data-view-name="profile-top-card"], section')
+    ).find((section) => section.querySelector("h1, h2")) || primary;
     const textElements = Array.from(
-      primary.querySelectorAll("p, span")
+      topCard.querySelectorAll("p, span")
     ).slice(0, 250);
     const controls = Array.from(
-      primary.querySelectorAll("button, a[aria-label], [role='button']")
+      topCard.querySelectorAll("button, a[aria-label], [role='button']")
     ).slice(0, 150);
 
     return {

--- a/lib/linkedin/linkedin.endorse.service.js
+++ b/lib/linkedin/linkedin.endorse.service.js
@@ -1,5 +1,6 @@
 const createLinkedinUrl = require("../helpers/create.linkedin.url");
 const LinkoutError = require("../errors/linkout-error");
+const { navigateLinkedIn } = require("../helpers/navigate-linkedin");
 const { clickVisible } = require("../interactions/browser-input");
 const { sleep } = require("../interactions/timing");
 const selectors = require("../selectors/actions").endorse;
@@ -58,7 +59,7 @@ async function waitForEndorsement(
 
 async function endorse(page, cdp, data = {}) {
   const target = await createLinkedinUrl(data.url, 3);
-  await page.goto(target);
+  await navigateLinkedIn(page, target, data);
   const transaction = await getActionPolicy(cdp, data).begin({
     operation: "endorse",
     target,

--- a/lib/linkedin/linkedin.like.service.js
+++ b/lib/linkedin/linkedin.like.service.js
@@ -1,4 +1,5 @@
 const createLinkedinUrl = require("../helpers/create.linkedin.url");
+const { navigateLinkedIn } = require("../helpers/navigate-linkedin");
 const selectors = require("../selectors/actions").like;
 const {
   assertAction,
@@ -8,7 +9,7 @@ const {
 
 async function like(page, cdp, data = {}) {
   const target = await createLinkedinUrl(data.url, 2);
-  await page.goto(target);
+  await navigateLinkedIn(page, target, data);
   const transaction = await getActionPolicy(cdp, data).begin({
     operation: "like",
     target,

--- a/lib/linkedin/linkedin.message.service.js
+++ b/lib/linkedin/linkedin.message.service.js
@@ -1,5 +1,6 @@
 const generateMessage = require("../helpers/generateMessage");
 const LinkoutError = require("../errors/linkout-error");
+const { navigateLinkedIn } = require("../helpers/navigate-linkedin");
 const selectors = require("../selectors/actions").message;
 const { detectPageState } = require("../browser/detect-page-state");
 const { clickVisible, typeVisible } = require("../interactions/browser-input");
@@ -385,7 +386,7 @@ async function waitForMessageSent(
 
 async function message(page, cdp, data = {}) {
   const { url, message: template, confirm = false } = data;
-  await page.goto(url);
+  await navigateLinkedIn(page, url, data);
   const target = await resolveProfileMessageTarget(page, url, data);
   const { profileData } = target;
 
@@ -398,9 +399,11 @@ async function message(page, cdp, data = {}) {
   });
 
   try {
-    await page.goto(target.href, {
-      waitUntil: "domcontentloaded",
-      timeout: data.navigationTimeout === undefined ? 30000 : data.navigationTimeout,
+    await navigateLinkedIn(page, target.href, {
+      ...data,
+      navigationTimeout: data.navigationTimeout === undefined
+        ? 30000
+        : data.navigationTimeout,
     });
     const compose = await verifyComposeRecipient(page, target, data);
     const renderedMessage = generateMessage(String(template || ""), profileData);

--- a/lib/linkedin/linkedin.messages.from.chat.service.js
+++ b/lib/linkedin/linkedin.messages.from.chat.service.js
@@ -2,6 +2,7 @@ const {
   findFirstSelector,
   waitForPageContext,
 } = require("../helpers/find-page-context");
+const { navigateLinkedIn } = require("../helpers/navigate-linkedin");
 const selectors = require("../selectors/read-only");
 
 function extractUserName(linkedinProfileUrl) {
@@ -110,7 +111,7 @@ async function messagesFromChat(page, cdp, data) {
     ? user
     : `https://www.linkedin.com/messaging/compose/?connId=${userName}`;
 
-  await page.goto(destination);
+  await navigateLinkedIn(page, destination, data);
 
   const rootContext = await waitForPageContext(
     page,

--- a/lib/linkedin/linkedin.visit.service.js
+++ b/lib/linkedin/linkedin.visit.service.js
@@ -1,11 +1,12 @@
 const scrapeProfileData = require("../helpers/scrapeProfileData");
 const timer = require("../helpers/timer");
 const LinkoutError = require("../errors/linkout-error");
+const { navigateLinkedIn } = require("../helpers/navigate-linkedin");
 
 async function visit(page, cdp, data) {
   const { url } = data;
 
-  await page.goto(url);
+  await navigateLinkedIn(page, url, data);
 
   await timer(2000);
 

--- a/test/core/selector-resolver.test.js
+++ b/test/core/selector-resolver.test.js
@@ -305,6 +305,31 @@ test("resolveSelector skips detached child frames and finds a stable frame", asy
   assert.equal(result.handle, target);
 });
 
+test("resolveSelector skips child frames with stalled selector lookup", async () => {
+  const target = handle();
+  const stalledFrame = {
+    async $$() {
+      return new Promise(() => {});
+    },
+  };
+  const stableFrame = context({ "main h2": target });
+  const page = Object.assign(context(), {
+    frames: () => [page, stalledFrame, stableFrame],
+    url: () => "https://www.linkedin.com/in/example/",
+  });
+
+  const result = await resolveSelector(page, {
+    workflow: "profile",
+    name: "name",
+    candidates: ["main h2"],
+    timeout: 50,
+    interval: 1,
+  });
+
+  assert.equal(result.context, stableFrame);
+  assert.equal(result.handle, target);
+});
+
 test("resolveSelector preserves unexpected child-frame failures", async () => {
   const failure = new Error("CDP session closed unexpectedly");
   const frame = {

--- a/test/helpers/navigate-linkedin.test.js
+++ b/test/helpers/navigate-linkedin.test.js
@@ -1,0 +1,31 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  DEFAULT_NAVIGATION_TIMEOUT,
+  navigateLinkedIn,
+  navigationTimeout,
+} = require("../../lib/helpers/navigate-linkedin");
+
+test("LinkedIn navigation defaults to DOMContentLoaded with a bounded timeout", async () => {
+  const calls = [];
+  const page = {
+    async goto(url, options) {
+      calls.push([url, options]);
+    },
+  };
+
+  await navigateLinkedIn(page, "https://www.linkedin.com/in/ada/");
+
+  assert.deepEqual(calls, [
+    [
+      "https://www.linkedin.com/in/ada/",
+      { waitUntil: "domcontentloaded", timeout: DEFAULT_NAVIGATION_TIMEOUT },
+    ],
+  ]);
+});
+
+test("LinkedIn navigation accepts explicit navigation timeout only", () => {
+  assert.equal(navigationTimeout({ navigationTimeout: 30000 }), 30000);
+  assert.equal(navigationTimeout({ timeout: 1 }), DEFAULT_NAVIGATION_TIMEOUT);
+});

--- a/test/interactions/browser-input.test.js
+++ b/test/interactions/browser-input.test.js
@@ -86,10 +86,36 @@ test("clickVisible can require a ghost cursor for top-level clicks", async () =>
         detectState: readyState,
         delay: 0,
         requireCursor: true,
+        loadCursor: async () => {},
       }
     ),
     (error) => error.code === "GHOST_CURSOR_REQUIRED"
   );
+});
+
+test("clickVisible loads a ghost cursor when top-level action clicks require it", async () => {
+  const calls = [];
+  const target = {};
+  const page = {};
+
+  await clickVisible(page, target, {
+    detectState: readyState,
+    delay: 0,
+    requireCursor: true,
+    loadCursor: async (loadedPage) => {
+      calls.push(["load", loadedPage === page]);
+      loadedPage.cursor = {
+        async click(value) {
+          calls.push(["cursor", value === target]);
+        },
+      };
+    },
+  });
+
+  assert.deepEqual(calls, [
+    ["load", true],
+    ["cursor", true],
+  ]);
 });
 
 test("clickVisible waits after a ghost cursor click", async () => {

--- a/test/read-only/connections.test.js
+++ b/test/read-only/connections.test.js
@@ -10,10 +10,12 @@ function connectionsPage(rows) {
 
   return {
     visited: null,
+    navigationOptions: null,
     queriedSelector: null,
     frames: () => [],
-    async goto(url) {
+    async goto(url, options) {
       this.visited = url;
+      this.navigationOptions = options;
     },
     async $(selector) {
       return selector === "main" || selector === currentSelector ? {} : null;
@@ -35,6 +37,10 @@ test("connections use current profile links and remove duplicates", async () => 
   const result = await acceptedConnections(page);
 
   assert.equal(page.queriedSelector, 'main a[href*="/in/"]');
+  assert.deepEqual(page.navigationOptions, {
+    waitUntil: "domcontentloaded",
+    timeout: 60000,
+  });
   assert.deepEqual(result, [
     { name: "Ada Lovelace", url: "https://www.linkedin.com/in/ada/" },
     { name: "Grace Hopper", url: "https://www.linkedin.com/in/grace/" },

--- a/test/read-only/messages.test.js
+++ b/test/read-only/messages.test.js
@@ -24,9 +24,11 @@ function messagingPage(rows, header = { name: "Nithis", img: "avatar.png" }) {
 
   return {
     visited: null,
+    navigationOptions: null,
     frames: () => [frame],
-    async goto(url) {
+    async goto(url, options) {
       this.visited = url;
+      this.navigationOptions = options;
     },
     async $() {
       return null;
@@ -59,6 +61,10 @@ test("message history uses the matching child frame and semantic rows", async ()
   });
 
   assert.match(page.visited, /\/messaging\/compose\/\?connId=ada$/);
+  assert.deepEqual(page.navigationOptions, {
+    waitUntil: "domcontentloaded",
+    timeout: 60000,
+  });
   assert.deepEqual(result, {
     name: "Nithis",
     img: "avatar.png",
@@ -82,6 +88,10 @@ test("message history accepts an existing thread URL without rewriting it", asyn
   });
 
   assert.equal(page.visited, threadUrl);
+  assert.deepEqual(page.navigationOptions, {
+    waitUntil: "domcontentloaded",
+    timeout: 60000,
+  });
   assert.deepEqual(result.values, []);
 });
 

--- a/test/read-only/profile.test.js
+++ b/test/read-only/profile.test.js
@@ -30,9 +30,11 @@ function profilePage(heading) {
 function statusPage(signals) {
   return {
     visited: null,
+    navigationOptions: null,
     frames: () => [],
-    async goto(url) {
+    async goto(url, options) {
       this.visited = url;
+      this.navigationOptions = options;
     },
     async $(selector) {
       return selector === "main" ? {} : null;
@@ -76,6 +78,10 @@ test("connection status detects a first-degree relationship", async () => {
     }),
     "Connected"
   );
+  assert.deepEqual(page.navigationOptions, {
+    waitUntil: "domcontentloaded",
+    timeout: 60000,
+  });
 });
 
 test("connection status detects a pending invitation", async () => {
@@ -115,14 +121,91 @@ test("connection status prefers an explicit connect CTA over unrelated first-deg
   );
 });
 
+test("connection status ignores connect buttons outside the profile top card", async () => {
+  const page = {
+    visited: null,
+    navigationOptions: null,
+    frames: () => [],
+    async goto(url, options) {
+      this.visited = url;
+      this.navigationOptions = options;
+    },
+    async $(selector) {
+      return selector === "main" ? {} : null;
+    },
+    async evaluate(callback) {
+      const fakeDocument = {
+        querySelector(selector) {
+          return selector === "main" ? this : null;
+        },
+        querySelectorAll(selector) {
+          if (selector === '[data-view-name="profile-top-card"], section') {
+            return [
+              {
+                querySelector(value) {
+                  return value === "h1, h2" ? {} : null;
+                },
+                querySelectorAll(value) {
+                  if (value === "p, span") {
+                    return [{ textContent: "· 1st" }];
+                  }
+                  if (value === "button, a[aria-label], [role='button']") {
+                    return [{ textContent: "Message", getAttribute: () => "" }];
+                  }
+                  return [];
+                },
+              },
+              {
+                querySelector(value) {
+                  return value === "h1, h2" ? {} : null;
+                },
+                querySelectorAll(value) {
+                  if (value === "button, a[aria-label], [role='button']") {
+                    return [{
+                      textContent: "Connect",
+                      getAttribute: () => "Invite Decoy to connect",
+                    }];
+                  }
+                  return [];
+                },
+              },
+            ];
+          }
+          return [];
+        },
+      };
+      global.document = fakeDocument;
+      try {
+        return callback();
+      } finally {
+        delete global.document;
+      }
+    },
+  };
+
+  assert.equal(
+    await connectionStatus(page, null, {
+      user: "https://www.linkedin.com/in/friend/",
+    }),
+    "Connected"
+  );
+});
+
 test("profile visit reports a structured failure when no member heading exists", async () => {
   const page = profilePage(null);
-  page.goto = async () => {};
+  let navigationOptions;
+  page.goto = async (_url, options) => {
+    navigationOptions = options;
+  };
 
   await assert.rejects(
     () => visit(page, null, { url: "https://www.linkedin.com/in/missing/" }),
     (error) => error.code === "PROFILE_NOT_FOUND"
   );
+  assert.deepEqual(navigationOptions, {
+    waitUntil: "domcontentloaded",
+    timeout: 60000,
+  });
 });
 
 test("profile and connection reads propagate unexpected page failures", async () => {

--- a/test/workflows/mutations.test.js
+++ b/test/workflows/mutations.test.js
@@ -212,8 +212,8 @@ function mutationPage(selectors = {}) {
     frameList: [],
     frames: () => page.frameList,
     url: () => page.currentUrl || "https://www.linkedin.com/feed/",
-    async goto(url) {
-      calls.push(["goto", url]);
+    async goto(url, options) {
+      calls.push(["goto", url, options]);
       page.currentUrl = url;
     },
     async $(selector) {
@@ -481,6 +481,13 @@ test("message waits for Send hydration and verifies a sent event", async () => {
     [
       "https://www.linkedin.com/in/ada/",
       "https://www.linkedin.com/messaging/compose/?recipient=ada-id",
+    ]
+  );
+  assert.deepEqual(
+    page.calls.filter(([name]) => name === "goto").map(([, , options]) => options),
+    [
+      { waitUntil: "domcontentloaded", timeout: 60000 },
+      { waitUntil: "domcontentloaded", timeout: 30000 },
     ]
   );
   assert.equal(


### PR DESCRIPTION
## Summary
- Bound LinkedIn service navigation to DOMContentLoaded with a fixed timeout so LinkedIn pages cannot stall selector checks on full page load.
- Skip stalled child-frame selector lookups while preserving main-page and unexpected selector failures.
- Scope connection status to the profile top card so suggestion-card Connect buttons do not override real 1st-degree status.
- Auto-load the ghost cursor before required top-level action clicks.
- Navigate custom-invite connect links directly when LinkedIn does not open the dialog from the anchor click.
- Re-check the current DOM after endorsement clicks because LinkedIn replaces the clicked button node.

## Checklist
- [x] Add regression coverage for bounded LinkedIn navigation.
- [x] Add regression coverage for stalled child-frame selector lookup.
- [x] Add regression coverage for slower main-page selector lookup.
- [x] Fix connection-status false negatives from suggestion-card Connect buttons.
- [x] Fix action services requiring callers to manually attach ghost cursor.
- [x] Fix live no-note connect through custom-invite flow.
- [x] Fix live endorsement verification after LinkedIn replaces the control.
- [x] Run offline suite: 130 tests, 129 passed, 1 opt-in live skipped, 0 failed.
- [x] Run security audit: npm audit --audit-level=moderate, 0 vulnerabilities.
- [x] Run authenticated live read-only selector smoke.
- [x] Verify live connection status for approved first-degree test profiles.
- [x] Test message action with approved first-degree test profiles through Linkout.
- [x] Test like action where a valid unliked activity control was present.
- [x] Test endorsement action where a valid unendorsed skill control was present.
- [x] Test connect without note on a non-terminal approved candidate; post-state is Pending.

No design/spec Markdown files are included. No personal target names are included.